### PR TITLE
Adding Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 
 python:
+  - "2.6"
   - "2.7"
   - "3.4"
 
@@ -11,6 +12,14 @@ env:
   - DJANGO_VERSION=1.5.10 DRF_VERSION=3.0.2
   - DJANGO_VERSION=1.6.7 DRF_VERSION=3.0.2
   - DJANGO_VERSION=1.7.1 DRF_VERSION=3.0.2
+
+matrix:
+  exclude:
+    # Django 1.7 dropped support for Python 2.6.
+    - python: "2.6"
+      env: DJANGO_VERSION=1.7.1 DRF_VERSION=2.4.4
+    - python: "2.6"
+      env: DJANGO_VERSION=1.7.1 DRF_VERSION=3.0.2
 
 install:
   - pip install -q Django==$DJANGO_VERSION

--- a/djoser/constants.py
+++ b/djoser/constants.py
@@ -4,5 +4,6 @@ INVALID_CREDENTIALS_ERROR = _('Unable to login with provided credentials.')
 DISABLE_ACCOUNT_ERROR = _('User account is disabled.')
 INVALID_TOKEN_ERROR = _('Invalid token for given user.')
 PASSWORD_MISMATCH_ERROR = _('The two password fields didn\'t match.')
-USERNAME_MISMATCH_ERROR = _('The two {} fields didn\'t match.')
+# Python 2.6 requires indices in the format specs.
+USERNAME_MISMATCH_ERROR = _('The two {0} fields didn\'t match.')
 INVALID_PASSWORD_ERROR = _('Invalid password.')

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -27,7 +27,8 @@ class RootView(generics.GenericAPIView):
             'password-reset-confirm': 'password_reset_confirm',
         }
 
-        # Do this in a way that works on Python 2.6.
+        # Python 2.6 doesn't have dict compehensions, so we can't use one
+        # here.
         return Response(
             dict([(key, reverse(url_name, request=request, format=format))
                   for key, url_name in urls_mapping.items()])

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -26,8 +26,12 @@ class RootView(generics.GenericAPIView):
             'password-reset': 'password_reset',
             'password-reset-confirm': 'password_reset_confirm',
         }
-        return Response({key: reverse(url_name, request=request, format=format)
-                         for key, url_name in urls_mapping.items()})
+
+        # Do this in a way that works on Python 2.6.
+        return Response(
+            dict([(key, reverse(url_name, request=request, format=format))
+                  for key, url_name in urls_mapping.items()])
+        )
 
 
 class RegistrationView(utils.SendEmailViewMixin, generics.CreateAPIView):


### PR DESCRIPTION
Thank you for generously offering to consider a pull request!

I'll delete my fork if this is accepted.

I tweaked the travis.yml file so that combinations of Python 2.6 and Django 1.7 won't be tested. This is appropriate as Django 1.7 dropped support for Python 2.6.

It passes all Travis tests. See attached image.

Thank you!

![screen shot 2015-03-03 at 9 58 16 am](https://cloud.githubusercontent.com/assets/231148/6468766/35bc020a-c18c-11e4-9e33-f62d4d4ad6c3.png)
