### PR TITLE
Allow email to be used for auth

### DIFF
--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -47,10 +47,11 @@ class LoginSerializer(serializers.Serializer):
     def __init__(self, *args, **kwargs):
         super(LoginSerializer, self).__init__(*args, **kwargs)
         self.user = None
-        self.fields[User.USERNAME_FIELD] = serializers.CharField(required=False)
+        self.fields[User.USERNAME_FIELD] = serializers.CharField(required=False, allow_blank=True)
+        self.fields['email'] = serializers.EmailField(required=False, allow_blank=True)
 
     def validate(self, attrs):
-        self.user = authenticate(username=attrs[User.USERNAME_FIELD], password=attrs['password'])
+        self.user = authenticate(**attrs)
         if self.user:
             if not self.user.is_active:
                 raise serializers.ValidationError(self.error_messages['inactive_account'])

--- a/testproject/auth_backends.py
+++ b/testproject/auth_backends.py
@@ -1,0 +1,19 @@
+from django.contrib.auth.backends import ModelBackend
+from django.contrib.auth import get_user_model
+
+
+class EmailAuthenticationBackend(ModelBackend):
+
+    def authenticate(self, **credentials):
+        ret = self._authenticate_by_email(**credentials)
+        return ret
+
+    def _authenticate_by_email(self, **credentials):
+        User = get_user_model()
+
+        email = credentials.get('email', credentials.get('username'))
+        if email:
+            user = User.objects.get(email=email)
+            if user.check_password(credentials["password"]):
+                return user
+        return None

--- a/testproject/auth_backends.py
+++ b/testproject/auth_backends.py
@@ -11,7 +11,7 @@ class EmailAuthenticationBackend(ModelBackend):
     def _authenticate_by_email(self, **credentials):
         User = get_user_model()
 
-        email = credentials.get('email', credentials.get('username'))
+        email = credentials.get('email')
         if email:
             user = User.objects.get(email=email)
             if user.check_password(credentials["password"]):

--- a/testproject/settings.py
+++ b/testproject/settings.py
@@ -15,6 +15,11 @@ SECRET_KEY = '_'
 
 MIDDLEWARE_CLASSES = ()
 
+AUTHENTICATION_BACKENDS = (
+        'django.contrib.auth.backends.ModelBackend',
+        'auth_backends.EmailAuthenticationBackend',
+    )
+
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -145,6 +145,53 @@ class LoginViewTest(restframework.APIViewTestCase,
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data['non_field_errors'], [djoser.constants.INVALID_CREDENTIALS_ERROR])
         self.assertTrue(self.signal_sent)
+    
+    def test_post_should_login_user_with_email(self):
+        user = create_user()
+        data = {
+            'email': user.email,
+            'password': user.raw_password,
+        }
+        user_logged_in.connect(self.signal_receiver)
+        request = self.factory.post(data=data)
+
+        response = self.view(request)
+
+        self.assert_status_equal(response, status.HTTP_200_OK)
+        self.assertEqual(response.data['auth_token'], user.auth_token.key)
+        self.assertTrue(self.signal_sent)
+
+    def test_post_should_not_login_with_email_if_user_is_not_active(self):
+        user = create_user()
+        data = {
+            'email': user.email,
+            'password': user.raw_password,
+        }
+        user.is_active = False
+        user.save()
+        user_logged_in.connect(self.signal_receiver)
+        request = self.factory.post(data=data)
+
+        response = self.view(request)
+
+        self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['non_field_errors'], [djoser.constants.INACTIVE_ACCOUNT_ERROR])
+        self.assertFalse(self.signal_sent)
+
+    def test_post_should_not_login_with_email_if_invalid_credentials(self):
+        user = create_user()
+        data = {
+            'email': user.email,
+            'password': 'wrong',
+        }
+        user_login_failed.connect(self.signal_receiver)
+        request = self.factory.post(data=data)
+
+        response = self.view(request)
+
+        self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['non_field_errors'], [djoser.constants.INVALID_CREDENTIALS_ERROR])
+        self.assertTrue(self.signal_sent)
 
 
 class LogoutViewTest(restframework.APIViewTestCase,


### PR DESCRIPTION
This provides the option of using email instead of username for auth. It works nicely with auth packages such as django-allauth, which provides an email authentication backend.
