### PR TITLE
Add namespace to djoser urls to prevent url clashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Configure `urls.py`:
 ```python
 urlpatterns = patterns('',
     (...),
-    url(r'^auth/', include('djoser.urls')),
+    url(r'^auth/', include('djoser.urls', namespace='djoser')),
 )
 ```
 
@@ -122,7 +122,7 @@ Configure `urls.py`. Pay attention to `djoser.url.authtoken` module path.
 ```python
 urlpatterns = patterns('',
     (...),
-    url(r'^auth/', include('djoser.urls.authtoken')),
+    url(r'^auth/', include('djoser.urls.authtoken', namespace='djoser')),
 )
 ```
 

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -34,7 +34,7 @@ class RootView(views.APIView):
 
     def get(self, request, format=None):
         return Response(
-            dict([(key, reverse('djoser:{}'.format(url_name), request=request, format=format))
+            dict([(key, reverse('djoser:{0}'.format(url_name), request=request, format=format))
                   for key, url_name in self.get_urls_mapping().items()])
         )
 

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -34,7 +34,7 @@ class RootView(views.APIView):
 
     def get(self, request, format=None):
         return Response(
-            dict([(key, reverse(url_name, request=request, format=format))
+            dict([(key, reverse('djoser:{}'.format(url_name), request=request, format=format))
                   for key, url_name in self.get_urls_mapping().items()])
         )
 

--- a/testproject/urls.py
+++ b/testproject/urls.py
@@ -2,5 +2,5 @@ from django.conf.urls import patterns, url, include
 
 
 urlpatterns = patterns('',
-    url(r'^auth/', include('djoser.urls.authtoken')),
+    url(r'^auth/', include('djoser.urls.authtoken', namespace='djoser')),
 )


### PR DESCRIPTION
Prevents url clashes with Django urls and other lib urls. This fixes issue #60.