### PR TITLE
Fix deprecated DRF code

### DIFF
--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -52,7 +52,7 @@ def send_email(to_email, from_email, context, subject_template_name,
 class ActionViewMixin(object):
 
     def post(self, request):
-        serializer = self.get_serializer(data=request.DATA)
+        serializer = self.get_serializer(data=request.data)
         if serializer.is_valid():
             return self.action(serializer)
         else:


### PR DESCRIPTION
DRF 3.2.0 breaks djoser, because `request.DATA` is deprecated. See here: http://www.django-rest-framework.org/topics/3.2-announcement/