### PR TITLE
Fix write_only_fields deprecated in DRF 3.2

### DIFF
--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -28,9 +28,11 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
             User._meta.pk.name,
             'password',
         )
-        write_only_fields = (
-            'password',
-        )
+        extra_kwargs = {
+            'password': {
+                'write_only': True,
+            },
+        }
 
     def create(self, validated_data):
         return User.objects.create_user(**validated_data)

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -54,6 +54,7 @@ class RegistrationViewTest(restframework.APIViewTestCase,
         response = self.view(request)
 
         self.assert_status_equal(response, status.HTTP_201_CREATED)
+        self.assertTrue('password' not in response.data)
         self.assert_instance_exists(get_user_model(), username=data['username'])
         user = get_user_model().objects.get(username=data['username'])
         self.assertTrue(user.check_password(data['password']))


### PR DESCRIPTION
The write_only_fields was marked deprecated in 3.0 and deprecated in 3.2. In the current version the users hashed password is returned in the JSON when registering. This commit fixes that.

http://www.django-rest-framework.org/topics/3.2-announcement/#deprecations