### PR TITLE
Fix deprecation and added style

### DIFF
--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -20,15 +20,13 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class UserRegistrationSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(style={'input_type': 'password'}, write_only=True)
 
     class Meta:
         model = User
         fields = tuple(User.REQUIRED_FIELDS) + (
             User.USERNAME_FIELD,
             User._meta.pk.name,
-            'password',
-        )
-        write_only_fields = (
             'password',
         )
 


### PR DESCRIPTION
write_only_fields are now deprecated in DRF 3.2 so I fixed that and I added a style for the browsable API that hides correctly the password typing