### PR TITLE
Fixed deprecated and added style for password

### DIFF
--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -20,15 +20,13 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class UserRegistrationSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(style={'input_type': 'password'}, write_only=True)
 
     class Meta:
         model = User
         fields = tuple(User.REQUIRED_FIELDS) + (
             User.USERNAME_FIELD,
             User._meta.pk.name,
-            'password',
-        )
-        write_only_fields = (
             'password',
         )
 

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -54,6 +54,7 @@ class RegistrationViewTest(restframework.APIViewTestCase,
         response = self.view(request)
 
         self.assert_status_equal(response, status.HTTP_201_CREATED)
+        self.assertTrue('password' not in response.data)
         self.assert_instance_exists(get_user_model(), username=data['username'])
         user = get_user_model().objects.get(username=data['username'])
         self.assertTrue(user.check_password(data['password']))


### PR DESCRIPTION
Removed deprecated write_only_fields in DRF 3.2 and added style for the input password in the register browsable API