### PR TITLE
 Add optional setting PASSWORD_VALIDATORS 

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ DJOSER = {
     'PASSWORD_RESET_CONFIRM_URL': '#/password/reset/confirm/{uid}/{token}',
     'ACTIVATION_URL': '#/activate/{uid}/{token}',
     'SEND_ACTIVATION_EMAIL': True,
+    'PASSWORD_VALIDATORS': []
 }
 ```
 
@@ -441,6 +442,14 @@ If `True`, you need to pass `re_new_password` to `/password/reset/confirm/`
 endpoint in order to validate password equality.
 
 **Default**: `False`
+
+### PASSWORD_VALIDATORS
+
+List containing import strings of [REST Framework Validators](http://www.django-rest-framework.org/api-guide/validators/).
+
+**Default**: `[]`
+
+**Example**: `["myapp.validators.validate_long_password", "myapp.validators.validate_strong_password"]`
 
 ## Emails
 

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -20,7 +20,9 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class UserRegistrationSerializer(serializers.ModelSerializer):
-    password = serializers.CharField(style={'input_type': 'password'}, write_only=True)
+    password = serializers.CharField(style={'input_type': 'password'},
+                                     write_only=True,
+                                     validators=utils.get_password_validators())
 
     class Meta:
         model = User
@@ -85,7 +87,8 @@ class UidAndTokenSerializer(serializers.Serializer):
 
 
 class PasswordSerializer(serializers.Serializer):
-    new_password = serializers.CharField(style={'input_type': 'password'})
+    new_password = serializers.CharField(style={'input_type': 'password'},
+                                         validators=utils.get_password_validators())
 
 
 class PasswordRetypeSerializer(PasswordSerializer):

--- a/djoser/settings.py
+++ b/djoser/settings.py
@@ -9,6 +9,7 @@ def get(key):
         'SET_USERNAME_RETYPE': False,
         'PASSWORD_RESET_CONFIRM_RETYPE': False,
         'ROOT_VIEW_URLS_MAPPING': {},
+        'PASSWORD_VALIDATORS': []
     }
     defaults.update(getattr(settings, 'DJOSER', {}))
     try:

--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -1,7 +1,9 @@
 from django.conf import settings as django_settings
 from django.core.mail import EmailMultiAlternatives, EmailMessage
 from django.template import loader
+from django.utils.module_loading import import_string
 from rest_framework import response, status
+from . import settings
 
 try:
     from django.contrib.sites.shortcuts import get_current_site
@@ -47,6 +49,11 @@ def send_email(to_email, from_email, context, subject_template_name,
         email_message.content_subtype = 'html'
 
     email_message.send()
+
+
+def get_password_validators():
+    return [import_string(validator_string)
+            for validator_string in settings.get('PASSWORD_VALIDATORS')]
 
 
 class ActionViewMixin(object):

--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -1,7 +1,6 @@
 from django.conf import settings as django_settings
 from django.core.mail import EmailMultiAlternatives, EmailMessage
 from django.template import loader
-from django.utils.module_loading import import_string
 from rest_framework import response, status
 from . import settings
 
@@ -9,6 +8,11 @@ try:
     from django.contrib.sites.shortcuts import get_current_site
 except ImportError:
     from django.contrib.sites.models import get_current_site
+
+try:
+    from django.utils.module_loading import import_string
+except ImportError:
+    from django.utils.module_loading import import_by_path as import_string
 
 
 def encode_uid(pk):


### PR DESCRIPTION
By default it's an empty list. When it has values, the password changes serializers validate the new password against the given validators.
Very useful with [django-passwords](https://github.com/dstufft/django-passwords/blob/master/passwords/validators.py) validators module.