### PR TITLE
More customisable user/registration serializers

### DIFF
--- a/djoser/constants.py
+++ b/djoser/constants.py
@@ -3,6 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 INVALID_CREDENTIALS_ERROR = _('Unable to login with provided credentials.')
 INACTIVE_ACCOUNT_ERROR = _('User account is disabled.')
 INVALID_TOKEN_ERROR = _('Invalid token for given user.')
+INVALID_UID_ERROR = _('Invalid id for the given user.')
 PASSWORD_MISMATCH_ERROR = _('The two password fields didn\'t match.')
 USERNAME_MISMATCH_ERROR = _('The two {0} fields didn\'t match.')
 INVALID_PASSWORD_ERROR = _('Invalid password.')

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -66,7 +66,8 @@ class UidAndTokenSerializer(serializers.Serializer):
     token = serializers.CharField()
 
     default_error_messages = {
-        'invalid_token': constants.INVALID_TOKEN_ERROR
+        'invalid_token': constants.INVALID_TOKEN_ERROR,
+        'invalid_uid': constants.INVALID_UID_ERROR
     }
 
     def validate_uid(self, value):
@@ -74,7 +75,7 @@ class UidAndTokenSerializer(serializers.Serializer):
             uid = utils.decode_uid(value)
             self.user = User.objects.get(pk=uid)
         except (User.DoesNotExist, ValueError, TypeError, OverflowError) as error:
-            raise serializers.ValidationError(error)
+            raise serializers.ValidationError(self.error_messages['invalid_uid'])
         return value
 
     def validate(self, attrs):

--- a/djoser/settings.py
+++ b/djoser/settings.py
@@ -9,6 +9,9 @@ def get(key):
         'SET_USERNAME_RETYPE': False,
         'PASSWORD_RESET_CONFIRM_RETYPE': False,
         'ROOT_VIEW_URLS_MAPPING': {},
+        'USER_SERIALIZER': 'djoser.serializers.UserSerializer',
+        'REGISTER_SERIALIZER': 'djoser.serializers.UserRegistrationSerializer'
+
     }
     defaults.update(getattr(settings, 'DJOSER', {}))
     try:

--- a/djoser/settings.py
+++ b/djoser/settings.py
@@ -10,7 +10,9 @@ def get(key):
         'PASSWORD_RESET_CONFIRM_RETYPE': False,
         'ROOT_VIEW_URLS_MAPPING': {},
         'USER_SERIALIZER': 'djoser.serializers.UserSerializer',
-        'REGISTER_SERIALIZER': 'djoser.serializers.UserRegistrationSerializer'
+        'REGISTER_SERIALIZER': 'djoser.serializers.UserRegistrationSerializer',
+        'ACTIVATION_EMAIL_SUBJECT': 'activation_email_subject.txt',
+        'ACTIVATION_EMAIL_BODY': 'activation_email_body.txt',
 
     }
     defaults.update(getattr(settings, 'DJOSER', {}))

--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -1,3 +1,4 @@
+import importlib
 from django.conf import settings as django_settings
 from django.core.mail import EmailMultiAlternatives, EmailMessage
 from django.template import loader
@@ -27,6 +28,12 @@ def decode_uid(pk):
     except ImportError:
         from django.utils.http import base36_to_int
         return base36_to_int(pk)
+
+
+def import_from_string(absolute_class_name):
+    module_name = absolute_class_name[0:absolute_class_name.rindex(".")]
+    class_name = absolute_class_name[absolute_class_name.rindex(".")+1:]
+    return getattr(importlib.import_module(module_name), class_name)
 
 
 def send_email(to_email, from_email, context, subject_template_name,

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -61,6 +61,8 @@ class RegistrationView(utils.SendEmailViewMixin, generics.CreateAPIView):
         signals.user_registered.send(sender=self.__class__, user=instance, request=self.request)
         if settings.get('SEND_ACTIVATION_EMAIL'):
             self.send_email(**self.get_send_email_kwargs(instance))
+            instance.is_active = False            
+            instance.save()
 
     def get_email_context(self, user):
         context = super(RegistrationView, self).get_email_context(user)

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -53,8 +53,8 @@ class RegistrationView(utils.SendEmailViewMixin, generics.CreateAPIView):
         permissions.AllowAny,
     )
     token_generator = default_token_generator
-    subject_template_name = 'activation_email_subject.txt'
-    plain_body_template_name = 'activation_email_body.txt'
+    subject_template_name = settings.get("ACTIVATION_EMAIL_SUBJECT")
+    plain_body_template_name = settings.get("ACTIVATION_EMAIL_BODY")
 
     def perform_create(self, serializer):
         instance = serializer.save()

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -7,7 +7,8 @@ from django.contrib.auth.tokens import default_token_generator
 from . import serializers, settings, utils, signals
 
 User = get_user_model()
-
+user_serializer_class = utils.import_from_string(settings.get("USER_SERIALIZER"))
+registration_serializer_class = utils.import_from_string(settings.get("REGISTER_SERIALIZER"))
 
 class RootView(views.APIView):
     """
@@ -46,7 +47,7 @@ class RegistrationView(utils.SendEmailViewMixin, generics.CreateAPIView):
     """
     Use this endpoint to register new user.
     """
-    serializer_class = serializers.UserRegistrationSerializer
+    serializer_class = registration_serializer_class
     permission_classes = (
         permissions.AllowAny,
     )
@@ -211,7 +212,7 @@ class UserView(generics.RetrieveUpdateAPIView):
     Use this endpoint to retrieve/update user.
     """
     model = User
-    serializer_class = serializers.UserSerializer
+    serializer_class = user_serializer_class
     permission_classes = (
         permissions.IsAuthenticated,
     )

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -10,6 +10,7 @@ User = get_user_model()
 user_serializer_class = utils.import_from_string(settings.get("USER_SERIALIZER"))
 registration_serializer_class = utils.import_from_string(settings.get("REGISTER_SERIALIZER"))
 
+
 class RootView(views.APIView):
     """
     Root endpoint - use one of sub endpoints.


### PR DESCRIPTION
I found it slightly complicated to allow additional fields for the user (e.g. first_name, last_name and fields in objects related by one-to-one keys). As far as I understood, this required adding REQUIRED_FIELDS to the User model which involves creating a custom user model. A simpler solution was just to allow user-defined serializers, which I implemented here (the defaults are UserSerializer and UserRegistrationSerializer). At the same time I allowed alternative locations for the activation email templates which saves overriding the registration view. 

There are also a couple of fixes in the commits:   
1. When SEND_ACTIVATION_EMAIL is true a newly created account should be inactive 
2. When the UID in activation is invalid, a simple error message is given (as opposed to the full detailed exception). 

Charanpal 

P.S. Thanks for the great library! 