### PR TITLE
Convert User.DoesNotExist to string before passing to ValidationError

### DIFF
--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -73,7 +73,9 @@ class UidAndTokenSerializer(serializers.Serializer):
         try:
             uid = utils.decode_uid(value)
             self.user = User.objects.get(pk=uid)
-        except (User.DoesNotExist, ValueError, TypeError, OverflowError) as error:
+        except User.DoesNotExist as error:
+            raise serializers.ValidationError(str(error))
+        except (ValueError, TypeError, OverflowError) as error:
             raise serializers.ValidationError(error)
         return value
 


### PR DESCRIPTION
If I post an invalid uid to the activation endpoint it passes the DoesNotExist exception directly to serializers.ValidationError which is raises `TypeError: DoesNotExist('User matching query does not exist.',) is not JSON serializable` and returns a 500 error to the user instead of a 400.