### PR TITLE
djoser returns a HTTP 400 for a stale activation token

### DIFF
--- a/djoser/constants.py
+++ b/djoser/constants.py
@@ -3,6 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 INVALID_CREDENTIALS_ERROR = _('Unable to login with provided credentials.')
 INACTIVE_ACCOUNT_ERROR = _('User account is disabled.')
 INVALID_TOKEN_ERROR = _('Invalid token for given user.')
+STALE_TOKEN_ERROR = _('Stale token for given user.')
 PASSWORD_MISMATCH_ERROR = _('The two password fields didn\'t match.')
 USERNAME_MISMATCH_ERROR = _('The two {0} fields didn\'t match.')
 INVALID_PASSWORD_ERROR = _('Invalid password.')

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -66,7 +66,8 @@ class UidAndTokenSerializer(serializers.Serializer):
     token = serializers.CharField()
 
     default_error_messages = {
-        'invalid_token': constants.INVALID_TOKEN_ERROR
+        'invalid_token': constants.INVALID_TOKEN_ERROR,
+        'stale_token': constants.STALE_TOKEN_ERROR
     }
 
     def validate_uid(self, value):
@@ -81,6 +82,8 @@ class UidAndTokenSerializer(serializers.Serializer):
         attrs = super(UidAndTokenSerializer, self).validate(attrs)
         if not self.context['view'].token_generator.check_token(self.user, attrs['token']):
             raise serializers.ValidationError(self.error_messages['invalid_token'])
+        if self.user.is_active and not attrs.get('new_password'):
+            raise serializers.ValidationError(self.error_messages['stale_token'])
         return attrs
 
 

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -8,6 +8,7 @@ from rest_framework import status
 import djoser.views
 import djoser.constants
 import djoser.utils
+import djoser.signals
 
 
 def create_user(**kwargs):
@@ -359,6 +360,12 @@ class ActivationViewTest(restframework.APIViewTestCase,
                          assertions.StatusCodeAssertionsMixin):
     view_class = djoser.views.ActivationView
 
+    def setUp(self):
+        self.signal_sent = False
+
+    def signal_receiver(self, *args, **kwargs):
+        self.signal_sent = True
+
     def test_post_should_activate_user_and_not_login(self):
         user = create_user()
         user.is_active = False
@@ -384,6 +391,27 @@ class ActivationViewTest(restframework.APIViewTestCase,
         response = self.view(request)
         response.render()
 
+        self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_post_should_respond_with_bad_request_when_stale_token(self):
+        user = create_user()
+        user.is_active = False
+        user.save()
+        djoser.signals.user_activated.connect(self.signal_receiver)
+
+        data = {
+            'uid': djoser.utils.encode_uid(user.pk),
+            'token': default_token_generator.make_token(user),
+        }
+        request = self.factory.post(data=data)
+
+        response = self.view(request)
+        self.assert_status_equal(response, status.HTTP_200_OK)
+        self.assertTrue(self.signal_sent)
+
+        request = self.factory.post(data=data)
+
+        response = self.view(request)
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
 
 


### PR DESCRIPTION
Hi folks, I assume this should be standard behaviour so I went ahead and wrote it. 

Let me know what you think :+1: 