### PR TITLE
RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated …

### DIFF
--- a/djoser/urls/authtoken.py
+++ b/djoser/urls/authtoken.py
@@ -1,9 +1,26 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from djoser import views
 from . import base
 
-urlpatterns = base.base_urlpatterns + patterns('',
-    url(r'^login/$', views.LoginView.as_view(), name='login'),
-    url(r'^logout/$', views.LogoutView.as_view(), name='logout'),
-    url(r'^$', views.RootView.as_view(urls_extra_mapping={'login': 'login', 'logout': 'logout'}), name='root'),
-)
+
+urlpatterns = base.base_urlpatterns + [
+    url(
+        r'^login/$',
+        views.LoginView.as_view(),
+        name='login'
+    ),
+
+    url(
+        r'^logout/$',
+        views.LogoutView.as_view(),
+        name='logout'
+    ),
+
+    url(
+        r'^$',
+        views.RootView.as_view(
+            urls_extra_mapping={'login': 'login', 'logout': 'logout'}
+        ),
+        name='root'
+    ),
+]

--- a/djoser/urls/base.py
+++ b/djoser/urls/base.py
@@ -1,17 +1,56 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from djoser import views
 from django.contrib.auth import get_user_model
 
 User = get_user_model()
 
-base_urlpatterns = patterns('',
-    url(r'^me/$', views.UserView.as_view(), name='user'),
-    url(r'^register/$', views.RegistrationView.as_view(), name='register'),
-    url(r'^activate/$', views.ActivationView.as_view(), name='activate'),
-    url(r'^{0}/$'.format(User.USERNAME_FIELD), views.SetUsernameView.as_view(), name='set_username'),
-    url(r'^password/$', views.SetPasswordView.as_view(), name='set_password'),
-    url(r'^password/reset/$', views.PasswordResetView.as_view(), name='password_reset'),
-    url(r'^password/reset/confirm/$', views.PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
-)
+base_urlpatterns = [
+    url(
+        r'^me/$',
+        views.UserView.as_view(),
+        name='user'
+    ),
 
-urlpatterns = base_urlpatterns + patterns('', url(r'^$', views.RootView.as_view(), name='root'))
+    url(
+        r'^register/$',
+        views.RegistrationView.as_view(),
+        name='register'
+    ),
+
+    url(
+        r'^activate/$',
+        views.ActivationView.as_view(),
+        name='activate'
+    ),
+
+    url(
+        r'^{0}/$'.format(User.USERNAME_FIELD),
+        views.SetUsernameView.as_view(),
+        name='set_username'
+    ),
+
+    url(
+        r'^password/$',
+        views.SetPasswordView.as_view(),
+        name='set_password'
+    ),
+
+    url(
+        r'^password/reset/$',
+        views.PasswordResetView.as_view(),
+        name='password_reset'
+    ),
+    url(
+        r'^password/reset/confirm/$',
+        views.PasswordResetConfirmView.as_view(),
+        name='password_reset_confirm'
+    ),
+]
+
+urlpatterns = base_urlpatterns + [
+    url(
+        r'^$',
+        views.RootView.as_view(),
+        name='root'
+    )
+]

--- a/testproject/urls.py
+++ b/testproject/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^auth/', include('djoser.urls.authtoken')),
-)
+]


### PR DESCRIPTION
Issue link : [https://github.com/sunscrapers/djoser/issues/101]

RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10 #101

- resolve the warning
- remove pylint errors from urls files