### PR TITLE
Added warning for referencing User directly from django.contrib.auth.models

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ method and have [USERNAME_FIELD](https://docs.djangoproject.com/en/dev/topics/au
 and [REQUIRED_FIELDS](https://docs.djangoproject.com/en/dev/topics/auth/customizing/#django.contrib.auth.models.CustomUser.REQUIRED_FIELDS)
 fields.
 
+If you are using a custom user model, make sure you use django.contrib.auth.get_user_model() instead of referencing User directly from django.contrib.auth.models.
+
 #### `POST`
 
 URL: `/register/`


### PR DESCRIPTION
Changed readme to help prevent a mistake which would result in "AttributeError: Manager isn't available; User has been swapped for \'app.UserModel\'"

If one was to use the web api from django-rest-framework as is, install Djoser, then try to implement a custom user model, they would run into this issue. Though I'm very new to Django and perhaps other users would not run into this problem, I had a lot of trouble with this since most of my searching for the said error lead to old StackOverflow questions that were unrelated to Djoser.

I think adding this little bit of text could potentially save users of Djoser from a lot of time searching online and looking in the wrong direction.