### PR TITLE
Add configurable password validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Supported Django versions:
 Supported Django Rest Framework versions:
 
  * Django Rest Framework 3.x
- 
-For Django Rest Framework 2.4 support check [djoser 0.3.2](https://github.com/sunscrapers/djoser/tree/0.3.2). 
+
+For Django Rest Framework 2.4 support check [djoser 0.3.2](https://github.com/sunscrapers/djoser/tree/0.3.2).
 
 ## Installation
 
@@ -149,6 +149,7 @@ DJOSER = {
     'PASSWORD_RESET_CONFIRM_URL': '#/password/reset/confirm/{uid}/{token}',
     'ACTIVATION_URL': '#/activate/{uid}/{token}',
     'SEND_ACTIVATION_EMAIL': True,
+    'PASSWORD_VALIDATORS': []
 }
 ```
 
@@ -445,6 +446,15 @@ If `True`, you need to pass `re_new_password` to `/password/reset/confirm/`
 endpoint in order to validate password equality.
 
 **Default**: `False`
+
+### PASSWORD_VALIDATORS
+
+List containing [REST Framework Validator](http://www.django-rest-framework.org/api-guide/validators/) functions.
+These validators are run on `/register/` and `/password/reset/confirm/`.
+
+**Default**: `[]`
+
+**Example**: `[my_validator1, my_validator2]`
 
 ## Emails
 

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import authenticate, get_user_model
 from rest_framework import exceptions, serializers
 from rest_framework.authtoken.models import Token
-from . import constants, utils
+from . import constants, utils, settings
 
 User = get_user_model()
 
@@ -20,7 +20,9 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class UserRegistrationSerializer(serializers.ModelSerializer):
-    password = serializers.CharField(style={'input_type': 'password'}, write_only=True)
+    password = serializers.CharField(style={'input_type': 'password'},
+                                     write_only=True,
+                                     validators=settings.get('PASSWORD_VALIDATORS'))
 
     class Meta:
         model = User
@@ -97,7 +99,8 @@ class ActivationSerializer(UidAndTokenSerializer):
 
 
 class PasswordSerializer(serializers.Serializer):
-    new_password = serializers.CharField(style={'input_type': 'password'})
+    new_password = serializers.CharField(style={'input_type': 'password'},
+                                         validators=settings.get('PASSWORD_VALIDATORS'))
 
 
 class PasswordRetypeSerializer(PasswordSerializer):

--- a/djoser/settings.py
+++ b/djoser/settings.py
@@ -9,6 +9,7 @@ def get(key):
         'SET_USERNAME_RETYPE': False,
         'PASSWORD_RESET_CONFIRM_RETYPE': False,
         'ROOT_VIEW_URLS_MAPPING': {},
+        'PASSWORD_VALIDATORS': []
     }
     defaults.update(getattr(settings, 'DJOSER', {}))
     try:

--- a/testproject/settings.py
+++ b/testproject/settings.py
@@ -1,4 +1,5 @@
 import os
+from testapp import validators
 
 from distutils.version import LooseVersion
 import django
@@ -52,4 +53,5 @@ if LooseVersion(django.get_version()) >= LooseVersion('1.8'):
 DJOSER = {
     'PASSWORD_RESET_CONFIRM_URL': '#/password/reset/confirm/{uid}/{token}',
     'ACTIVATION_URL': '#/activate/{uid}/{token}',
+    'PASSWORD_VALIDATORS': [validators.is_666],
 }

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -89,6 +89,19 @@ class RegistrationViewTest(restframework.APIViewTestCase,
 
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
 
+    def test_post_should_not_register_if_fails_password_validation(self):
+        data = {
+            'username': 'john',
+            'password': '666',
+            'csrftoken': 'asdf',
+        }
+        request = self.factory.post(data=data)
+
+        response = self.view(request)
+
+        self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, {'password':['Woops, 666 is not allowed.']})
+
 
 class LoginViewTest(restframework.APIViewTestCase,
                     assertions.StatusCodeAssertionsMixin,
@@ -354,6 +367,21 @@ class PasswordResetConfirmViewTest(restframework.APIViewTestCase,
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
         user = utils.refresh(user)
         self.assertFalse(user.check_password(data['new_password']))
+
+    @override_settings(DJOSER=dict(settings.DJOSER, **{'PASSWORD_RESET_CONFIRM_RETYPE': True}))
+    def test_post_should_not_reset_if_fails_password_validation(self):
+        user = create_user()
+        data = {
+            'uid': djoser.utils.encode_uid(user.pk),
+            'token': default_token_generator.make_token(user),
+            'new_password': '666',
+            're_new_password': 'isokpassword',
+        }
+
+        request = self.factory.post(data=data)
+        response = self.view(request)
+        self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, {'new_password':['Woops, 666 is not allowed.']})
 
 
 class ActivationViewTest(restframework.APIViewTestCase,

--- a/testproject/testapp/validators.py
+++ b/testproject/testapp/validators.py
@@ -1,0 +1,4 @@
+def is_666(value):
+    from rest_framework import serializers
+    if value == '666':
+        raise serializers.ValidationError('Woops, 666 is not allowed.')


### PR DESCRIPTION
Based on the awesome work of #86, but instead of passing absolute path strings for validators, you just pass the functions (closer to DRF way?) and has some tests.

If this PR goes in, would close #86 and #107.