### PR TITLE
Django 1.9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
   - TOX_ENV=py35-dj19-drf33
 
 install:
-  - pip install tox
+  - travis_retry pip install "virtualenv<14.0.0" "tox>=1.9"
 
 script:
   - tox -e $TOX_ENV

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Supported Django versions:
  * Django 1.6
  * Django 1.7
  * Django 1.8
+ * Django 1.9
 
 Supported Django Rest Framework versions:
 

--- a/djoser/urls/authtoken.py
+++ b/djoser/urls/authtoken.py
@@ -1,8 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from djoser import views
 from . import base
 
-urlpatterns = base.base_urlpatterns + patterns('',
+urlpatterns = base.base_urlpatterns + (
     url(r'^login/$', views.LoginView.as_view(), name='login'),
     url(r'^logout/$', views.LogoutView.as_view(), name='logout'),
     url(r'^$', views.RootView.as_view(urls_extra_mapping={'login': 'login', 'logout': 'logout'}), name='root'),

--- a/djoser/urls/base.py
+++ b/djoser/urls/base.py
@@ -1,10 +1,10 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from djoser import views
 from django.contrib.auth import get_user_model
 
 User = get_user_model()
 
-base_urlpatterns = patterns('',
+base_urlpatterns = (
     url(r'^me/$', views.UserView.as_view(), name='user'),
     url(r'^register/$', views.RegistrationView.as_view(), name='register'),
     url(r'^activate/$', views.ActivationView.as_view(), name='activate'),
@@ -14,4 +14,4 @@ base_urlpatterns = patterns('',
     url(r'^password/reset/confirm/$', views.PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
 )
 
-urlpatterns = base_urlpatterns + patterns('', url(r'^$', views.RootView.as_view(), name='root'))
+urlpatterns = base_urlpatterns + (url(r'^$', views.RootView.as_view(), name='root'),)

--- a/testproject/settings.py
+++ b/testproject/settings.py
@@ -1,5 +1,9 @@
 import os
 
+from distutils.version import LooseVersion
+import django
+
+
 DEBUG = True
 
 BASE_DIR = os.path.dirname(__file__)
@@ -37,9 +41,13 @@ REST_FRAMEWORK = {
 
 ROOT_URLCONF = 'urls'
 
-TEMPLATE_DIRS = (
-    os.path.join(BASE_DIR, 'templates'),
-)
+if LooseVersion(django.get_version()) >= LooseVersion('1.8'):
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'APP_DIRS': True,
+        },
+    ]
 
 DJOSER = {
     'PASSWORD_RESET_CONFIRM_URL': '#/password/reset/confirm/{uid}/{token}',

--- a/testproject/urls.py
+++ b/testproject/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 
 
-urlpatterns = patterns('',
+urlpatterns = (
     url(r'^auth/', include('djoser.urls.authtoken')),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -17,12 +17,12 @@ basepython =
     py34: python3.4
     py35: python3.5
 deps =
-    dj15: django==1.5.12
-    dj16: django==1.6.11
-    dj17: django==1.7.11
-    dj18: django==1.8.7
-    dj19: django==1.9
-    drf32: djangorestframework==3.2.5
-    drf33: djangorestframework==3.3.1
+    dj15: django>=1.5,<1.6
+    dj16: django>=1.6,<1.7
+    dj17: django>=1.7,<1.8
+    dj18: django>=1.8,<1.9
+    dj19: django>=1.9,<1.10
+    drf32: djangorestframework>=3.2,<3.3
+    drf33: djangorestframework>=3.3,<3.4
     -rrequirements-test.txt
 commands = coverage run --source=djoser testproject/manage.py test testapp


### PR DESCRIPTION
Improve TOX configuration. Now, dependencies are specified by a version range.
Rather than a version specified by a patch revision.
We don't need to commit anything when new patch revision becomes available.
To our taste, this is fair - testing all historical patches takes a lot of time
and end-users should use the newest revision always.

Remove deprecated django.conf.urls.patterns
This function is deprecated since Django 1.8. We remove usage of this
function for all supported Django versions. For more detail read:
https://docs.djangoproject.com/en/1.8/ref/urls/#patterns

Remove TEMPLATE_DIRS from testproject settings. This settings is deprecated in Django 1.8.
We remove this setting, because is not used in testproject, and is deprecated in Django 1.8.
This setting was required in Django 1.4 and not in Django 1.5.
Read more at: https://docs.djangoproject.com/en/1.8/ref/settings/#template-dirs

Travis configured to use python 3.2
Travis uses by default virtualenv 14. This version of virtualenv do not support Python 3.2.
So we configure Travis to install virtualenv in version lower than 14.
Read more about this issue: https://github.com/travis-ci/travis-ci/issues/5485
We will come back to newest virtualenv, when we stop supporting Python 3.2

Added TEMPLATES settings to testproject for Django >= 1.8.
This setting will be introduced in Django 1.8, and it will be obligatory in Django 1.10.
The lack of this setting in Django 1.9 causes warning