### PR TITLE
Use RegexField in UidAndTokenSerializer.

### DIFF
--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -62,8 +62,8 @@ class PasswordResetSerializer(serializers.Serializer):
 
 
 class UidAndTokenSerializer(serializers.Serializer):
-    uid = serializers.CharField()
-    token = serializers.CharField()
+    uid = serializers.RegexField(regex=r'[0-9A-Za-z_\-]+$', required=True)
+    token = serializers.RegexField(regex=r'[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20}$', required=True)
 
     default_error_messages = {
         'invalid_token': constants.INVALID_TOKEN_ERROR,

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -289,6 +289,22 @@ class PasswordResetConfirmViewTest(restframework.APIViewTestCase,
         user = utils.refresh(user)
         self.assertFalse(user.check_password(data['new_password']))
 
+    def test_post_should_not_set_new_password_if_invalid_token(self):
+        user = create_user()
+        data = {
+            'uid': djoser.utils.encode_uid(user.pk),
+            'token': default_token_generator.make_token(user).split('-')[0],
+            'new_password': 'new password',
+        }
+        request = self.factory.post(data=data)
+
+        response = self.view(request)
+
+        self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('token', response.data)
+        user = utils.refresh(user)
+        self.assertFalse(user.check_password(data['new_password']))
+
     def test_post_should_not_set_new_password_if_user_does_not_exist(self):
         user = create_user()
         data = {


### PR DESCRIPTION
Hi, 

I have changed the two fields ( `uid` and `token` ) in `UidAndTokenSerializer` since these fields are expected to meet some regex. I have just ported from django's  auth urls.
Perhaps you like it.

Thank you