### PR TITLE
Human readable error message when incorrect uid is provided

### DIFF
--- a/djoser/constants.py
+++ b/djoser/constants.py
@@ -3,6 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 INVALID_CREDENTIALS_ERROR = _('Unable to login with provided credentials.')
 INACTIVE_ACCOUNT_ERROR = _('User account is disabled.')
 INVALID_TOKEN_ERROR = _('Invalid token for given user.')
+INVALID_UID_ERROR = _('Invalid user id or user doesn\'t exist.')
 STALE_TOKEN_ERROR = _('Stale token for given user.')
 PASSWORD_MISMATCH_ERROR = _('The two password fields didn\'t match.')
 USERNAME_MISMATCH_ERROR = _('The two {0} fields didn\'t match.')

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -69,6 +69,7 @@ class UidAndTokenSerializer(serializers.Serializer):
 
     default_error_messages = {
         'invalid_token': constants.INVALID_TOKEN_ERROR,
+        'invalid_uid': constants.INVALID_UID_ERROR,
     }
 
     def validate_uid(self, value):
@@ -76,7 +77,7 @@ class UidAndTokenSerializer(serializers.Serializer):
             uid = utils.decode_uid(value)
             self.user = User.objects.get(pk=uid)
         except (User.DoesNotExist, ValueError, TypeError, OverflowError) as error:
-            raise serializers.ValidationError(str(error))
+            raise serializers.ValidationError(self.error_messages['invalid_uid'])
         return value
 
     def validate(self, attrs):

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -302,6 +302,30 @@ class PasswordResetConfirmViewTest(restframework.APIViewTestCase,
         user = utils.refresh(user)
         self.assertFalse(user.check_password(data['new_password']))
 
+    def test_post_readable_error_message_when_uid_is_broken(self):
+        """ Regression test for https://github.com/sunscrapers/djoser/issues/122
+
+        When uid is not correct unicode string, error message was looked like:
+        'utf-8' codec can't decode byte 0xd3 in position 0: invalid continuation byte.
+        You passed in b'\xd3\x10\xb4' (<class 'bytes'>)
+
+        Now we provide human readable message
+        """
+        user = create_user()
+        data = {
+            'uid': b'\xd3\x10\xb4',
+            'token': default_token_generator.make_token(user),
+            'new_password': 'new password',
+        }
+        request = self.factory.post(data=data)
+
+        response = self.view(request)
+
+        self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('uid', response.data)
+        self.assertEqual(len(response.data['uid']), 1)
+        self.assertEqual(response.data['uid'][0], djoser.constants.INVALID_UID_ERROR)
+
     def test_post_should_not_set_new_password_if_user_does_not_exist(self):
         user = create_user()
         data = {


### PR DESCRIPTION
We add invalid uid error message to UidAndTokenSerializer.
This serializer is used in ActivationView and PasswordResetConfirmView.