### PR TITLE
Sanitization for username + tests. Closes #146

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ DJOSER = {
     'ACTIVATION_URL': '#/activate/{uid}/{token}',
     'SEND_ACTIVATION_EMAIL': True,
     'PASSWORD_VALIDATORS': [],
+    'USERNAME_SANITIZERS': [],
     'SERIALIZERS': {},
 }
 ```
@@ -456,6 +457,19 @@ These validators are run on `/register/` and `/password/reset/confirm/`.
 **Default**: `[]`
 
 **Example**: `[my_validator1, my_validator2]`
+
+### USERNAME_SANITIZERS
+
+List of functions - operations on string, that should be applied on username during: registration, login and getting
+new username. Allows to keep usernames in desired format in database without direct interference and despite of users
+habits.
+
+Each sanitizer function must return string. If you provide sanitizers having already not empty database, remember to
+rename usernames in database explicitly.
+
+**Default**: `[]`
+
+**Example**: `['myapp.sanitizers.myfunc1', 'myapp.sanitizers.myfunc2']`
 
 ### SERIALIZERS
 

--- a/djoser/settings.py
+++ b/djoser/settings.py
@@ -11,6 +11,7 @@ default_settings = {
     'PASSWORD_RESET_CONFIRM_RETYPE': False,
     'ROOT_VIEW_URLS_MAPPING': {},
     'PASSWORD_VALIDATORS': [],
+    'USERNAME_SANITIZERS': [],
     'SERIALIZERS': {
         'activation': 'djoser.serializers.ActivationSerializer',
         'login': 'djoser.serializers.LoginSerializer',

--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -1,12 +1,17 @@
 from django.conf import settings as django_settings
+from django.contrib.auth import get_user_model
 from django.core.mail import EmailMultiAlternatives, EmailMessage
 from django.template import loader
+from django.utils.module_loading import import_string
 from rest_framework import response, status
+from . import settings
 
 try:
     from django.contrib.sites.shortcuts import get_current_site
 except ImportError:
     from django.contrib.sites.models import get_current_site
+
+User = get_user_model()
 
 
 def encode_uid(pk):
@@ -47,6 +52,13 @@ def send_email(to_email, from_email, context, subject_template_name,
         email_message.content_subtype = 'html'
 
     email_message.send()
+
+
+def sanitize(text):
+    sanitizers = settings.get('USERNAME_SANITIZERS')
+    for sanitizer in sanitizers:
+        text = import_string(sanitizer)(text)
+    return text
 
 
 class ActionViewMixin(object):

--- a/testproject/testapp/sanitizers.py
+++ b/testproject/testapp/sanitizers.py
@@ -1,0 +1,6 @@
+def uppercase(name):
+    return name.upper()
+
+
+def trim3(name):
+    return name[:3]

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -666,6 +666,7 @@ class SetUsernameViewTest(restframework.APIViewTestCase,
         user = utils.refresh(user)
         self.assertNotEqual(user.username, data['new_username'])
 
+
 class UserViewTest(restframework.APIViewTestCase,
                    assertions.StatusCodeAssertionsMixin):
     view_class = djoser.views.UserView


### PR DESCRIPTION
Didn't work out sanitization for dictionary, because LoginSerializer doesn't provide dictionary. Could go around, but decided to create sanitization for string argument.
Included sanitization in 3 classes: UserRegistrationSerializer, LoginSerializer and SetUsernameSerializer.
Created 3 tests for each use case - similar to primary tests. Created list of 2 test sanitizers: uppercase and trim3, to check if works for list of sanitizers.
