### PR TITLE
Add support for Drf 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,25 @@ env:
   - TOX_ENV=py33-dj17-drf33
   - TOX_ENV=py34-dj17-drf33
   - TOX_ENV=py27-dj18-drf34
+  - TOX_ENV=py27-dj18-drf35
   - TOX_ENV=py27-dj19-drf34
+  - TOX_ENV=py27-dj19-drf35
   - TOX_ENV=py27-dj110-drf34
+  - TOX_ENV=py27-dj110-drf35
   - TOX_ENV=py33-dj18-drf34
+  - TOX_ENV=py33-dj18-drf35
   - TOX_ENV=py34-dj18-drf34
+  - TOX_ENV=py34-dj18-drf35
   - TOX_ENV=py35-dj18-drf34
+  - TOX_ENV=py35-dj18-drf35
   - TOX_ENV=py34-dj19-drf34
+  - TOX_ENV=py34-dj19-drf35
   - TOX_ENV=py34-dj110-drf34
+  - TOX_ENV=py34-dj110-drf35
   - TOX_ENV=py35-dj19-drf34
+  - TOX_ENV=py35-dj19-drf35
   - TOX_ENV=py35-dj110-drf34
+  - TOX_ENV=py35-dj110-drf35
 
 install:
   - travis_retry pip install virtualenv tox

--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -35,13 +35,8 @@ class ActionViewMixin(object):
 
     def post(self, request):
         serializer = self.get_serializer(data=request.data)
-        if serializer.is_valid():
-            return self._action(serializer)
-        else:
-            return response.Response(
-                data=serializer.errors,
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        serializer.is_valid(raise_exception=True)
+        return self._action(serializer)
 
 
 class UserEmailFactoryBase(object):

--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -36,7 +36,7 @@ class ActionViewMixin(object):
     def post(self, request):
         serializer = self.get_serializer(data=request.data)
         if serializer.is_valid():
-            return self.action(serializer)
+            return self._action(serializer)
         else:
             return response.Response(
                 data=serializer.errors,

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -86,7 +86,7 @@ class LoginView(utils.ActionViewMixin, generics.GenericAPIView):
         permissions.AllowAny,
     )
 
-    def action(self, serializer):
+    def _action(self, serializer):
         token = utils.login_user(self.request, serializer.user)
         token_serializer_class = serializers.serializers_manager.get('token')
         return Response(
@@ -119,7 +119,7 @@ class PasswordResetView(utils.ActionViewMixin, generics.GenericAPIView):
 
     _users = None
 
-    def action(self, serializer):
+    def _action(self, serializer):
         for user in self.get_users(serializer.data['email']):
             self.send_password_reset_email(user)
         return response.Response(status=status.HTTP_204_NO_CONTENT)
@@ -152,7 +152,7 @@ class SetPasswordView(utils.ActionViewMixin, generics.GenericAPIView):
             return serializers.serializers_manager.get('set_password_retype')
         return serializers.serializers_manager.get('set_password')
 
-    def action(self, serializer):
+    def _action(self, serializer):
         self.request.user.set_password(serializer.data['new_password'])
         self.request.user.save()
 
@@ -176,7 +176,7 @@ class PasswordResetConfirmView(utils.ActionViewMixin, generics.GenericAPIView):
             return serializers.serializers_manager.get('password_reset_confirm_retype')
         return serializers.serializers_manager.get('password_reset_confirm')
 
-    def action(self, serializer):
+    def _action(self, serializer):
         serializer.user.set_password(serializer.data['new_password'])
         serializer.user.save()
         return response.Response(status=status.HTTP_204_NO_CONTENT)
@@ -192,7 +192,7 @@ class ActivationView(utils.ActionViewMixin, generics.GenericAPIView):
     )
     token_generator = default_token_generator
 
-    def action(self, serializer):
+    def _action(self, serializer):
         serializer.user.is_active = True
         serializer.user.save()
         signals.user_activated.send(
@@ -218,7 +218,7 @@ class SetUsernameView(utils.ActionViewMixin, generics.GenericAPIView):
             return serializers.serializers_manager.get('set_username_retype')
         return serializers.serializers_manager.get('set_username')
 
-    def action(self, serializer):
+    def _action(self, serializer):
         setattr(self.request.user, User.USERNAME_FIELD, serializer.data['new_' + User.USERNAME_FIELD])
         self.request.user.save()
         return response.Response(status=status.HTTP_204_NO_CONTENT)

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -11,6 +11,7 @@ from django.test.testcases import SimpleTestCase
 from djet import assertions, utils, restframework
 
 from rest_framework import status, authtoken
+from rest_framework.request import Request, override_method
 
 import djoser.views
 import djoser.constants
@@ -801,3 +802,19 @@ class TestMergeSettingsDict(SimpleTestCase):
             self.assertTrue(False)
         except Exception as error:
             self.assertEqual(str(error), 'Conflict at 1.1')
+
+
+class TestDjoserViewsSupportActionAttribute(restframework.APIViewTestCase):
+    # any arbitraty view from djoser
+    view_class = djoser.views.UserView
+
+    def test_action_reflect_http_method(self):
+        request = self.factory.get()
+
+        view = self.view_class()
+        view.action_map = {'get': 'retrieve'}
+
+        # reproduce DRF wrapping
+        with override_method(view, Request(request), 'GET') as request:
+            view.dispatch(request)
+            self.assertEqual(view.action, 'retrieve')

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ downloadcache = {toxworkdir}/cache/
 envlist =
     py27-dj17-drf33,
     py{33,34}-dj17-drf33,
-    py27-dj{18,19,110}-drf34,
-    py{33,34,35}-dj18-drf34,
-    py{34,35}-dj{19,110}-drf34
+    py27-dj{18,19,110}-drf{34,35},
+    py{33,34,35}-dj18-drf{34,35},
+    py{34,35}-dj{19,110}-drf{34,35}
 
 [testenv]
 basepython =
@@ -20,6 +20,7 @@ deps =
     dj110: django>=1.10,<1.11
     drf33: djangorestframework>=3.3,<3.4
     drf34: djangorestframework>=3.4,<3.5
+    drf35: djangorestframework>=3.5,<3.6
     py27: mock
     -rrequirements-test.txt
 commands = coverage run --source=djoser testproject/manage.py test testapp


### PR DESCRIPTION
This PR essentialy rename `View.action` into `View._action` because `View.action` is a reserved attribute of DRF.

https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/request.py#L56

This change is potentially backward incompatible, as such, a changelog entry should explain the steps and/or published with a major version bump (at the appreciation of the maintainers).

fixes #171