### PR TITLE
Added queryset because it breaks swagger

### DIFF
--- a/djoser/views.py
+++ b/djoser/views.py
@@ -228,6 +228,7 @@ class UserView(generics.RetrieveUpdateAPIView):
     permission_classes = (
         permissions.IsAuthenticated,
     )
+    queryset = User.objects.all()
 
     def get_object(self, *args, **kwargs):
         return self.request.user


### PR DESCRIPTION
First of all, thanks for this marvellous module. 🍻

Swagger was complaining about the missing `queryset` attribute. It's a `RetrieveUpdate` view, I don't know why it requires a `queryset` but I managed to work it around by simply putting it. I do not think it will cause any security harm because the view itself does not have a list endpoint but it is still not seem like to be the correct way to fix it. Feel free to decline the PR. I just wanted to point it out.

My configuration for `django_rest_swagger` is pretty generic. So I do not think it would be an issue to reproduce it.