### PR TITLE
Remove User.REQUIRED_FIELDS from fields attribute on user serializers

### DIFF
--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -14,9 +14,10 @@ User = get_user_model()
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = tuple(User.REQUIRED_FIELDS) + (
+        fields = (
             User._meta.pk.name,
             User.USERNAME_FIELD,
+            User.EMAIL_FIELD,
         )
         read_only_fields = (
             User.USERNAME_FIELD,
@@ -46,8 +47,11 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = tuple(User.REQUIRED_FIELDS) + (
-            User.USERNAME_FIELD, User._meta.pk.name, 'password',
+        fields = (
+            User.USERNAME_FIELD,
+            User.EMAIL_FIELD,
+            User._meta.pk.name,
+            'password',
         )
 
     def create(self, validated_data):

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -19,7 +19,7 @@ class UserSerializer(serializers.ModelSerializer):
         fields = (
             User._meta.pk.name,
             User.USERNAME_FIELD,
-            USER_EMAIL_FIELD,
+            USER_EMAIL_FIELD
         )
         read_only_fields = (
             User.USERNAME_FIELD,

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -10,6 +10,8 @@ from . import constants, utils, settings
 
 User = get_user_model()
 
+USER_EMAIL_FIELD = getattr(User, 'EMAIL_FIELD', 'email')
+
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
@@ -17,7 +19,7 @@ class UserSerializer(serializers.ModelSerializer):
         fields = (
             User._meta.pk.name,
             User.USERNAME_FIELD,
-            User.EMAIL_FIELD,
+            USER_EMAIL_FIELD,
         )
         read_only_fields = (
             User.USERNAME_FIELD,
@@ -49,7 +51,7 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
         model = User
         fields = (
             User.USERNAME_FIELD,
-            User.EMAIL_FIELD,
+            USER_EMAIL_FIELD,
             User._meta.pk.name,
             'password',
         )

--- a/djoser/settings.py
+++ b/djoser/settings.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
+from django.test.utils import setting_changed
 
 
 default_settings = {
@@ -29,6 +30,7 @@ default_settings = {
         'token': 'djoser.serializers.TokenSerializer',
     },
     'LOGOUT_ON_PASSWORD_CHANGE': False,
+    'USER_REQUIRED_FIELDS': []
 }
 
 
@@ -64,3 +66,11 @@ def merge_settings_dicts(a, b, path=None, overwrite_conflicts=True):
             a[key] = b[key]
     # Don't let this fool you that a is not modified in place
     return a
+
+
+def reload_djoser_settings(*args, **kwargs):
+    setting, value = kwargs['setting'], kwargs['value']
+    if 'DJOSER' == setting:
+        settings.DJOSER.update(value)
+
+setting_changed.connect(reload_djoser_settings)

--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -57,7 +57,13 @@ class RequiredUserFieldsMixin(object):
         if extra_meta_attrs and isinstance(extra_meta_attrs, dict):
             meta_attrs.update(extra_meta_attrs)
 
-        Meta = type('Meta', (serializer_class.Meta,), meta_attrs)
+        # If parent serializer class already has an inner Meta, the Meta we're
+        # creating needs to inherit from the parent's inner meta.
+        meta_parent = (object,)
+        if hasattr(serializer_class, 'Meta'):
+            meta_parent = (object, serializer_class.Meta)
+
+        Meta = type('Meta', meta_parent, meta_attrs)
 
         new_serializer_class_attrs = {
             'Meta': Meta

--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -61,7 +61,7 @@ class RequiredUserFieldsMixin(object):
         # creating needs to inherit from the parent's inner meta.
         meta_parent = (object,)
         if hasattr(serializer_class, 'Meta'):
-            meta_parent = (object, serializer_class.Meta)
+            meta_parent = (serializer_class.Meta, object)
 
         Meta = type('Meta', meta_parent, meta_attrs)
 

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -43,7 +43,7 @@ class RootView(views.APIView):
         )
 
 
-class RegistrationView(generics.CreateAPIView):
+class RegistrationView(utils.RequiredUserFieldsMixin, generics.CreateAPIView):
     """
     Use this endpoint to register new user.
     """
@@ -224,7 +224,7 @@ class SetUsernameView(utils.ActionViewMixin, generics.GenericAPIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class UserView(generics.RetrieveUpdateAPIView):
+class UserView(utils.RequiredUserFieldsMixin, generics.RetrieveUpdateAPIView):
     """
     Use this endpoint to retrieve/update user.
     """

--- a/docs/source/endpoints.rst
+++ b/docs/source/endpoints.rst
@@ -15,13 +15,13 @@ Use this endpoint to retrieve/update user.
 |          |                                |                                  |
 |          |                                | * ``{{ User.USERNAME_FIELD }}``  |
 |          |                                | * ``{{ User._meta.pk.name }}``   |
-|          |                                | * ``{{ User.REQUIRED_FIELDS }}`` |
+|          |                                | * ``{{ User.EMAIL_FIELD }}``     |
 +----------+--------------------------------+----------------------------------+
-| ``PUT``  | ``{{ User.REQUIRED_FIELDS }}`` | ``HTTP_200_OK``                  |
+| ``PUT``  | ``{{ User.EMAIL_FIELD }}``     | ``HTTP_200_OK``                  |
 |          |                                |                                  |
 |          |                                | * ``{{ User.USERNAME_FIELD }}``  |
 |          |                                | * ``{{ User._meta.pk.name }}``   |
-|          |                                | * ``{{ User.REQUIRED_FIELDS }}`` |
+|          |                                | * ``{{ User.EMAIL_FIELD }}``     |
 +----------+--------------------------------+----------------------------------+
 
 Register
@@ -30,7 +30,7 @@ Register
 Use this endpoint to register new user. Your user model manager should
 implement `create_user <https://docs.djangoproject.com/en/dev/ref/contrib/auth/#django.contrib.auth.models.UserManager.create_user>`_
 method and have `USERNAME_FIELD <https://docs.djangoproject.com/en/dev/topics/auth/customizing/#django.contrib.auth.models.CustomUser.USERNAME_FIELD>`_
-and `REQUIRED_FIELDS <https://docs.djangoproject.com/en/dev/topics/auth/customizing/#django.contrib.auth.models.CustomUser.REQUIRED_FIELDS>`_
+and `EMAIL_FIELD <https://docs.djangoproject.com/en/dev/topics/auth/customizing/#django.contrib.auth.models.CustomUser.EMAIL_FIELD>`_
 fields.
 
 **Default URL**: ``/register/``
@@ -39,10 +39,10 @@ fields.
 | Method   |  Request                          | Response                         |
 +==========+===================================+==================================+
 | ``POST`` | * ``{{ User.USERNAME_FIELD }}``   | ``HTTP_201_CREATED``             |
-|          | * ``{{ User.REQUIRED_FIELDS }}``  |                                  |
+|          | * ``{{ User.EMAIL_FIELD }}``      |                                  |
 |          | * ``password``                    | * ``{{ User.USERNAME_FIELD }}``  |
 |          |                                   | * ``{{ User._meta.pk.name }}``   |
-|          |                                   | * ``{{ User.REQUIRED_FIELDS }}`` |
+|          |                                   | * ``{{ User.EMAIL_FIELD }}``     |
 +----------+-----------------------------------+----------------------------------+
 
 Login

--- a/docs/source/endpoints.rst
+++ b/docs/source/endpoints.rst
@@ -15,13 +15,13 @@ Use this endpoint to retrieve/update user.
 |          |                                |                                  |
 |          |                                | * ``{{ User.USERNAME_FIELD }}``  |
 |          |                                | * ``{{ User._meta.pk.name }}``   |
-|          |                                | * ``{{ User.EMAIL_FIELD }}``     |
+|          |                                | * ``{{ EMAIL_FIELD }}``          |
 +----------+--------------------------------+----------------------------------+
-| ``PUT``  | ``{{ User.EMAIL_FIELD }}``     | ``HTTP_200_OK``                  |
+| ``PUT``  | ``{{ EMAIL_FIELD }}``          | ``HTTP_200_OK``                  |
 |          |                                |                                  |
 |          |                                | * ``{{ User.USERNAME_FIELD }}``  |
 |          |                                | * ``{{ User._meta.pk.name }}``   |
-|          |                                | * ``{{ User.EMAIL_FIELD }}``     |
+|          |                                | * ``{{ EMAIL_FIELD }}``          |
 +----------+--------------------------------+----------------------------------+
 
 Register
@@ -29,9 +29,10 @@ Register
 
 Use this endpoint to register new user. Your user model manager should
 implement `create_user <https://docs.djangoproject.com/en/dev/ref/contrib/auth/#django.contrib.auth.models.UserManager.create_user>`_
-method and have `USERNAME_FIELD <https://docs.djangoproject.com/en/dev/topics/auth/customizing/#django.contrib.auth.models.CustomUser.USERNAME_FIELD>`_
-and `EMAIL_FIELD <https://docs.djangoproject.com/en/dev/topics/auth/customizing/#django.contrib.auth.models.CustomUser.EMAIL_FIELD>`_
-fields.
+method. Your user model should have fields:
+
+    * `USERNAME_FIELD <https://docs.djangoproject.com/en/dev/topics/auth/customizing/#django.contrib.auth.models.CustomUser.USERNAME_FIELD>`_
+    * `email <https://docs.djangoproject.com/en/1.10/ref/contrib/auth/#django.contrib.auth.models.User.email>`_ for Django 1.10 and older or `EMAIL_FIELD <https://docs.djangoproject.com/en/dev/topics/auth/customizing/#django.contrib.auth.models.CustomUser.EMAIL_FIELD>`_ for Django 1.11 and newer
 
 **Default URL**: ``/register/``
 
@@ -39,10 +40,10 @@ fields.
 | Method   |  Request                          | Response                         |
 +==========+===================================+==================================+
 | ``POST`` | * ``{{ User.USERNAME_FIELD }}``   | ``HTTP_201_CREATED``             |
-|          | * ``{{ User.EMAIL_FIELD }}``      |                                  |
+|          | * ``{{ EMAIL_FIELD }}``           |                                  |
 |          | * ``password``                    | * ``{{ User.USERNAME_FIELD }}``  |
 |          |                                   | * ``{{ User._meta.pk.name }}``   |
-|          |                                   | * ``{{ User.EMAIL_FIELD }}``     |
+|          |                                   | * ``{{ EMAIL_FIELD }}``          |
 +----------+-----------------------------------+----------------------------------+
 
 Login

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -13,6 +13,7 @@ You may optionally provide ``DJOSER`` settings:
         'SEND_ACTIVATION_EMAIL': True,
         'PASSWORD_VALIDATORS': [],
         'SERIALIZERS': {},
+        'USER_REQUIRED_FIELDS': [],
     }
 
 DOMAIN
@@ -154,6 +155,36 @@ let's say, one key, all the others will still be used.
         'user': 'djoser.serializers.UserSerializer',
         'token': 'djoser.serializers.TokenSerializer',
     }
+
+
+
+USER_REQUIRED_FIELDS
+--------------------
+
+Additional field names to be added to `Meta.fields` of `UserRegistrationSerializer` and `UserSerializer`.
+
+**Example**
+
+Given djoser settings:
+
+.. code-block:: python
+
+    DJOSER = {
+        ...
+        'USER_REQUIRED_FIELDS': ['first_name'],
+        ...
+    }
+
+is equivalent to
+
+.. code-block:: python
+
+    class CustomUserRegistrationSerializer(UserRegistrationSerializer):
+        first_name = serializers.CharField(required=True)
+
+        class Meta(UserRegistrationSerializer.Meta):
+            fields = UserRegistrationSerializer.Meta.fields + ['first_name']
+
 
 USE_HTML_EMAIL_TEMPLATES
 ------------------------


### PR DESCRIPTION
User.REQUIRED_FIELDS is meant to be used only by createsuperuser management command

Resolves: #136 