### PR TITLE
Initialize serializers dict on __init__ in SerializerManager

### DIFF
--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -246,7 +246,7 @@ class SerializersManager(object):
         self.serializers = {}
         for serializer_name, serializer in serializer_confs.copy():
             if isinstance(serializer, six.string_types):
-                serializer = self.load_serializer(serializer)
+                serializer = import_string(serializer)
             self.serializers[serializer_name] = serializer
 
     def get(self, serializer_name):
@@ -258,7 +258,5 @@ class SerializersManager(object):
                 tuple(settings.get('SERIALIZERS').keys())
             ))
 
-    def load_serializer(self, serializer_class):
-        return import_string(serializer_class)
 
 serializers_manager = SerializersManager(settings.get('SERIALIZERS'))

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -243,13 +243,14 @@ class TokenSerializer(serializers.ModelSerializer):
 
 class SerializersManager(object):
     def __init__(self, serializer_confs):
-        self.serializers = serializer_confs.copy()
+        self.serializers = {}
+        for serializer_name, serializer in serializer_confs.copy():
+            if isinstance(serializer, six.string_types):
+                serializer = self.load_serializer(serializer)
+            self.serializers[serializer_name] = serializer
 
     def get(self, serializer_name):
         try:
-            if isinstance(self.serializers[serializer_name], six.string_types):
-                self.serializers[serializer_name] = self.load_serializer(
-                    self.serializers[serializer_name])
             return self.serializers[serializer_name]
         except KeyError:
             raise Exception("Try to use serializer name '%s' that is not one of: %s" % (

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -244,7 +244,7 @@ class TokenSerializer(serializers.ModelSerializer):
 class SerializersManager(object):
     def __init__(self, serializer_confs):
         self.serializers = {}
-        for serializer_name, serializer in serializer_confs.copy():
+        for serializer_name, serializer in serializer_confs.copy().iteritems():
             if isinstance(serializer, six.string_types):
                 serializer = import_string(serializer)
             self.serializers[serializer_name] = serializer

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -244,7 +244,7 @@ class TokenSerializer(serializers.ModelSerializer):
 class SerializersManager(object):
     def __init__(self, serializer_confs):
         self.serializers = {}
-        for serializer_name, serializer in serializer_confs.copy().iteritems():
+        for serializer_name, serializer in six.iteritems(serializer_confs.copy()):
             if isinstance(serializer, six.string_types):
                 serializer = import_string(serializer)
             self.serializers[serializer_name] = serializer

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -830,11 +830,10 @@ class SerializersManagerTest(SimpleTestCase):
         serializer_class = serializers_manager.get('user')
         self.assertTrue(issubclass(serializer_class, djoser.serializers.UserSerializer))
 
-        with mock.patch.object(
-                djoser.serializers.SerializersManager, 'load_serializer') as load_serializer_mock:
+        with mock.patch('django.utils.module_loading.import_string') as import_string_mock:
             serializer_class = serializers_manager.get('user')
             self.assertTrue(issubclass(serializer_class, djoser.serializers.UserSerializer))
-            self.assertFalse(load_serializer_mock.called)
+            self.assertFalse(import_string_mock.called)
 
 
 class TestMergeSettingsDict(SimpleTestCase):


### PR DESCRIPTION
Stumbled upon this piece of code and found it hard to read.
Now get method has only one responibility and loading serializers is
moved to __init__ method.