### PR TITLE
Add support for Django Password Validators

### DIFF
--- a/djoser/compat.py
+++ b/djoser/compat.py
@@ -1,0 +1,4 @@
+try:
+    from django.contrib.auth.password_validation import validate_password
+except ImportError:
+    from password_validation import validate_password

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -8,6 +8,12 @@ Installation
 
     $ pip install -U djoser
 
+.. warning::
+
+    If you are Django 1.8.x user you will need to install
+    `django-password-validation <https://github.com/orcasgit/django-password-validation/>`_
+    with ``pip install django-password-validation``.
+
 Configuration
 -------------
 

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -11,7 +11,6 @@ You may optionally provide ``DJOSER`` settings:
         'PASSWORD_RESET_CONFIRM_URL': '#/password/reset/confirm/{uid}/{token}',
         'ACTIVATION_URL': '#/activate/{uid}/{token}',
         'SEND_ACTIVATION_EMAIL': True,
-        'PASSWORD_VALIDATORS': [],
         'SERIALIZERS': {},
     }
 
@@ -111,16 +110,6 @@ Please note that setting this to ``True`` will expose information whether
 an email is registered in the system.
 
 **Default**: ``False``
-
-PASSWORD_VALIDATORS
--------------------
-
-List containing `REST Framework Validator <http://www.django-rest-framework.org/api-guide/validators/>`_ functions.
-These validators are run on ``/register/`` and ``/password/reset/confirm/``.
-
-**Default**: ``[]``
-
-**Example**: ``[my_validator1, my_validator2]``
 
 SERIALIZERS
 -----------

--- a/testproject/settings.py
+++ b/testproject/settings.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import
+from django.utils.module_loading import import_string
 import os
-from testapp import validators
 
 from distutils.version import LooseVersion
 import django
@@ -15,6 +16,8 @@ DATABASES = {
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
 }
+
+AUTH_PASSWORD_VALIDATORS = [{'NAME': 'testapp.validators.Is666'}]
 
 SECRET_KEY = '_'
 
@@ -53,5 +56,4 @@ if LooseVersion(django.get_version()) >= LooseVersion('1.8'):
 DJOSER = {
     'PASSWORD_RESET_CONFIRM_URL': '#/password/reset/confirm/{uid}/{token}',
     'ACTIVATION_URL': '#/activate/{uid}/{token}',
-    'PASSWORD_VALIDATORS': [validators.is_666],
 }

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -81,7 +81,9 @@ class RegistrationViewTest(restframework.APIViewTestCase,
         user = get_user_model().objects.get(username=data['username'])
         self.assertTrue(user.check_password(data['password']))
 
-    @override_settings(DJOSER=dict(settings.DJOSER, **{'SEND_ACTIVATION_EMAIL': True}))
+    @override_settings(
+        DJOSER=dict(settings.DJOSER, **{'SEND_ACTIVATION_EMAIL': True})
+    )
     def test_post_should_create_user_with_login_and_send_activation_email(self):
         data = {
             'username': 'john',
@@ -100,7 +102,9 @@ class RegistrationViewTest(restframework.APIViewTestCase,
         user = get_user_model().objects.get(username='john')
         self.assertFalse(user.is_active)
 
-    @override_settings(DJOSER=dict(settings.DJOSER, **{'SEND_CONFIRMATION_EMAIL': True}))
+    @override_settings(
+        DJOSER=dict(settings.DJOSER, **{'SEND_CONFIRMATION_EMAIL': True})
+    )
     def test_post_should_create_user_with_login_and_send_confirmation_email(self):
         data = {
             'username': 'john',
@@ -138,12 +142,15 @@ class RegistrationViewTest(restframework.APIViewTestCase,
             'password': '666',
             'csrftoken': 'asdf',
         }
-        request = self.factory.post(data=data)
 
+        request = self.factory.post(data=data)
         response = self.view(request)
 
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data, {'password': ['Woops, 666 is not allowed.']})
+        self.assertEqual(
+            response.data,
+            {'password': ['Password 666 is not allowed.']}
+        )
 
     @mock.patch('djoser.serializers.UserRegistrationSerializer.perform_create',
                 side_effect=perform_create_mock)
@@ -222,7 +229,10 @@ class LoginViewTest(restframework.APIViewTestCase,
         response = self.view(request)
 
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data['non_field_errors'], [djoser.constants.INVALID_CREDENTIALS_ERROR])
+        self.assertEqual(
+            response.data['non_field_errors'],
+            [djoser.constants.INVALID_CREDENTIALS_ERROR]
+        )
         self.assertFalse(self.signal_sent)
 
     def test_post_should_not_login_if_invalid_credentials(self):
@@ -237,7 +247,10 @@ class LoginViewTest(restframework.APIViewTestCase,
         response = self.view(request)
 
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data['non_field_errors'], [djoser.constants.INVALID_CREDENTIALS_ERROR])
+        self.assertEqual(
+            response.data['non_field_errors'],
+            [djoser.constants.INVALID_CREDENTIALS_ERROR]
+        )
         self.assertTrue(self.signal_sent)
 
     def test_post_should_not_login_if_empty_request(self):
@@ -247,7 +260,10 @@ class LoginViewTest(restframework.APIViewTestCase,
         response = self.view(request)
 
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data['non_field_errors'], [djoser.constants.INVALID_CREDENTIALS_ERROR])
+        self.assertEqual(
+            response.data['non_field_errors'],
+            [djoser.constants.INVALID_CREDENTIALS_ERROR]
+        )
 
 
 class LogoutViewTest(restframework.APIViewTestCase,
@@ -428,7 +444,9 @@ class PasswordResetConfirmViewTest(restframework.APIViewTestCase,
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
         self.assertIn('uid', response.data)
         self.assertEqual(len(response.data['uid']), 1)
-        self.assertEqual(response.data['uid'][0], djoser.constants.INVALID_UID_ERROR)
+        self.assertEqual(
+            response.data['uid'][0], djoser.constants.INVALID_UID_ERROR
+        )
 
     def test_post_should_not_set_new_password_if_user_does_not_exist(self):
         user = create_user()
@@ -458,11 +476,16 @@ class PasswordResetConfirmViewTest(restframework.APIViewTestCase,
         response = self.view(request)
 
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data['non_field_errors'], [djoser.constants.INVALID_TOKEN_ERROR])
+        self.assertEqual(
+            response.data['non_field_errors'],
+            [djoser.constants.INVALID_TOKEN_ERROR]
+        )
         user = utils.refresh(user)
         self.assertFalse(user.check_password(data['new_password']))
 
-    @override_settings(DJOSER=dict(settings.DJOSER, **{'PASSWORD_RESET_CONFIRM_RETYPE': True}))
+    @override_settings(
+        DJOSER=dict(settings.DJOSER, **{'PASSWORD_RESET_CONFIRM_RETYPE': True})
+    )
     def test_post_should_not_set_new_password_if_password_mismatch(self):
         user = create_user()
         data = {
@@ -476,7 +499,10 @@ class PasswordResetConfirmViewTest(restframework.APIViewTestCase,
         response = self.view(request)
 
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data['non_field_errors'], [djoser.constants.PASSWORD_MISMATCH_ERROR])
+        self.assertEqual(
+            response.data['non_field_errors'],
+            [djoser.constants.PASSWORD_MISMATCH_ERROR]
+        )
 
     @override_settings(DJOSER=dict(settings.DJOSER, **{'PASSWORD_RESET_CONFIRM_RETYPE': True}))
     def test_post_should_not_set_new_password_if_mismatch(self):
@@ -496,7 +522,9 @@ class PasswordResetConfirmViewTest(restframework.APIViewTestCase,
         user = utils.refresh(user)
         self.assertFalse(user.check_password(data['new_password']))
 
-    @override_settings(DJOSER=dict(settings.DJOSER, **{'PASSWORD_RESET_CONFIRM_RETYPE': True}))
+    @override_settings(
+        DJOSER=dict(settings.DJOSER, **{'PASSWORD_RESET_CONFIRM_RETYPE': True})
+    )
     def test_post_should_not_reset_if_fails_password_validation(self):
         user = create_user()
         data = {
@@ -509,7 +537,9 @@ class PasswordResetConfirmViewTest(restframework.APIViewTestCase,
         request = self.factory.post(data=data)
         response = self.view(request)
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data, {'new_password': ['Woops, 666 is not allowed.']})
+        self.assertEqual(
+            response.data, {'new_password': ['Password 666 is not allowed.']}
+        )
 
 
 class ActivationViewTest(restframework.APIViewTestCase,
@@ -629,7 +659,7 @@ class SetPasswordViewTest(restframework.APIViewTestCase,
         user = utils.refresh(user)
         self.assertTrue(user.check_password(data['current_password']))
 
-    def test_post_should_not_set_new_password_if_fails_password_validation(self):
+    def test_post_should_not_set_new_password_if_fails_validation(self):
         user = create_user()
         data = {
             'new_password': '666',
@@ -641,7 +671,9 @@ class SetPasswordViewTest(restframework.APIViewTestCase,
         response = self.view(request)
 
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data, {'new_password': ['Woops, 666 is not allowed.']})
+        self.assertEqual(
+            response.data, {'new_password': ['Password 666 is not allowed.']}
+        )
 
     @override_settings(DJOSER=dict(settings.DJOSER, **{'LOGOUT_ON_PASSWORD_CHANGE': True}))
     def test_post_should_logout_after_password_change(self):

--- a/testproject/testapp/validators.py
+++ b/testproject/testapp/validators.py
@@ -1,4 +1,7 @@
-def is_666(value):
-    from rest_framework import serializers
-    if value == '666':
-        raise serializers.ValidationError('Woops, 666 is not allowed.')
+from django.core.exceptions import ValidationError
+
+
+class Is666(object):
+    def validate(self, password, *args, **kwargs):
+        if password == '666':
+            raise ValidationError("Password 666 is not allowed.")

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ basepython =
     py36: python3.6
 deps =
     dj18: django>=1.8,<1.9
+    dj18: django-password-validation
     dj19: django>=1.9,<1.10
     dj110: django>=1.10,<1.11
     dj111: django>=1.11,<2.0


### PR DESCRIPTION
Remove support for DRF validators as password validators
Update documentation
Update tests

Based on #176 and #177 