### PR TITLE
Update docs to remove Basic Authentication

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -17,8 +17,8 @@ Available endpoints
 Supported authentication backends
 ---------------------------------
 
-* `HTTP Basic Auth <http://www.django-rest-framework.org/api-guide/authentication/#basicauthentication>`_ (Default)
 * `Token based authentication from DRF <http://www.django-rest-framework.org/api-guide/authentication#tokenauthentication>`_
+* `JWT Token based authentication from DRF <http://getblimp.github.io/django-rest-framework-jwt/>`_
 
 Supported Python versions
 -------------------------


### PR DESCRIPTION
As I saw with regards to @KaczuH comments in #185 - the docs should no longer mention Basic Authentication to avoid confusion, and instead mention using JWT as a possibility