### PR TITLE
Reregistration Flows

### DIFF
--- a/djoser/conf.py
+++ b/djoser/conf.py
@@ -15,6 +15,7 @@ default_settings = {
     'USE_HTML_EMAIL_TEMPLATES': False,
     'SEND_ACTIVATION_EMAIL': False,
     'SEND_CONFIRMATION_EMAIL': False,
+    'SEND_REREGISTRATION_EMAIL': False,
     'SET_PASSWORD_RETYPE': False,
     'SET_USERNAME_RETYPE': False,
     'PASSWORD_RESET_CONFIRM_RETYPE': False,
@@ -38,6 +39,7 @@ default_settings = {
     },
     'LOGOUT_ON_PASSWORD_CHANGE': False,
     'USER_EMAIL_FIELD_NAME': 'email',
+    'REREGISTRATION_SHOW_RESPONSE': True,
 }
 
 SETTINGS_TO_IMPORT = ['TOKEN_MODEL']

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -72,7 +72,6 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
         return user
 
 
-
 class LoginSerializer(serializers.Serializer):
     password = serializers.CharField(
         required=False, style={'input_type': 'password'}

--- a/djoser/templates/reregistration_email_body.html
+++ b/djoser/templates/reregistration_email_body.html
@@ -1,0 +1,17 @@
+{% load i18n %}{% autoescape off %}
+<html>
+<body>
+<p>
+{% blocktrans %}You're receiving this email because someone tried to reregister your user account at {{ site_name }}.{% endblocktrans %}</p>
+
+<p>{% trans "Please go to the following page and choose a new password:" %}</p>
+<p>{% block reset_link %}
+<a href="{{ protocol }}://{{ domain }}/{{ url }}">{{ protocol }}://{{ domain }}/{{ url }}</a>
+{% endblock %}</p>
+<p>{% trans "Your username, in case you've forgotten:" %} <b>{{ user.get_username }}</b></p>
+
+<p>{% trans "Thanks for using our site!" %}</p>
+
+<p>{% blocktrans %}The {{ site_name }} team{% endblocktrans %}</p>
+</body></html>
+{% endautoescape %}

--- a/djoser/templates/reregistration_email_body.html
+++ b/djoser/templates/reregistration_email_body.html
@@ -2,9 +2,9 @@
 <html>
 <body>
 <p>
-{% blocktrans %}You're receiving this email because someone tried to reregister your user account at {{ site_name }}.{% endblocktrans %}</p>
+{% blocktrans %}You're receiving this email because someone tried to reregister a user account with this email at {{ site_name }}.{% endblocktrans %}</p>
 
-<p>{% trans "Please go to the following page and choose a new password:" %}</p>
+<p>{% trans "If this wasn't you, please go to the following page and choose a new password:" %}</p>
 <p>{% block reset_link %}
 <a href="{{ protocol }}://{{ domain }}/{{ url }}">{{ protocol }}://{{ domain }}/{{ url }}</a>
 {% endblock %}</p>

--- a/djoser/templates/reregistration_email_body.txt
+++ b/djoser/templates/reregistration_email_body.txt
@@ -1,0 +1,14 @@
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}You're receiving this email because someone tried to reregister your user account at {{ site_name }}.{% endblocktrans %}
+
+{% trans "Please go to the following page and choose a new password:" %}
+{% block reset_link %}
+{{ protocol }}://{{ domain }}/{{ url }}
+{% endblock %}
+{% trans "Your username, in case you've forgotten:" %} {{ user.get_username }}
+
+{% trans "Thanks for using our site!" %}
+
+{% blocktrans %}The {{ site_name }} team{% endblocktrans %}
+
+{% endautoescape %}

--- a/djoser/templates/reregistration_email_body.txt
+++ b/djoser/templates/reregistration_email_body.txt
@@ -1,5 +1,5 @@
 {% load i18n %}{% autoescape off %}
-{% blocktrans %}You're receiving this email because someone tried to reregister a user account with this email at {{ site_name }}.{% endblocktrans %}</p>
+{% blocktrans %}You're receiving this email because someone tried to reregister a user account with this email at {{ site_name }}.{% endblocktrans %}
 
 {% trans "If this wasn't you, please go to the following page and choose a new password:" %}
 {% block reset_link %}

--- a/djoser/templates/reregistration_email_body.txt
+++ b/djoser/templates/reregistration_email_body.txt
@@ -1,7 +1,7 @@
 {% load i18n %}{% autoescape off %}
-{% blocktrans %}You're receiving this email because someone tried to reregister your user account at {{ site_name }}.{% endblocktrans %}
+{% blocktrans %}You're receiving this email because someone tried to reregister a user account with this email at {{ site_name }}.{% endblocktrans %}</p>
 
-{% trans "Please go to the following page and choose a new password:" %}
+{% trans "If this wasn't you, please go to the following page and choose a new password:" %}
 {% block reset_link %}
 {{ protocol }}://{{ domain }}/{{ url }}
 {% endblock %}

--- a/djoser/templates/reregistration_email_subject.txt
+++ b/djoser/templates/reregistration_email_subject.txt
@@ -1,0 +1,3 @@
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}Reregistration requested on {{ site_name }}{% endblocktrans %}
+{% endautoescape %}

--- a/djoser/templates/reregistration_inactive_email_body.html
+++ b/djoser/templates/reregistration_inactive_email_body.html
@@ -1,0 +1,14 @@
+{% load i18n %}{% autoescape off %}
+<html>
+<body>
+<p>
+{% blocktrans %}You're receiving this email because someone tried to reregister your user account at {{ site_name }}.{% endblocktrans %}</p>
+{% blocktrans %}Please find the previously sent activation email, or request a new one to properly set this account up{% endblocktrans %}
+
+<p>{% trans "Your username, in case you've forgotten:" %} <b>{{ user.get_username }}</b></p>
+
+<p>{% trans "Thanks for using our site!" %}</p>
+
+<p>{% blocktrans %}The {{ site_name }} team{% endblocktrans %}</p>
+</body></html>
+{% endautoescape %}

--- a/djoser/templates/reregistration_inactive_email_body.txt
+++ b/djoser/templates/reregistration_inactive_email_body.txt
@@ -1,0 +1,11 @@
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}You're receiving this email because someone tried to reregister your user account at {{ site_name }}.{% endblocktrans %}
+{% blocktrans %}Please find the previously sent activation email, or request a new one to properly set this account up{% endblocktrans %}
+
+{% trans "Your username, in case you've forgotten:" %} {{ user.get_username }}
+
+{% trans "Thanks for using our site!" %}
+
+{% blocktrans %}The {{ site_name }} team{% endblocktrans %}
+
+{% endautoescape %}

--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -143,6 +143,20 @@ class UserPasswordResetEmailFactory(UserEmailFactoryBase):
         return context
 
 
+class UserReregistrationEmailFactory(UserEmailFactoryBase):
+    subject_template_name = 'reregistration_email_subject.txt'
+    plain_body_template_name = 'reregistration_email_body.txt'
+    if settings.USE_HTML_EMAIL_TEMPLATES:
+        html_body_template_name = 'reregistration_email_body.html'
+
+    def get_context(self):
+        context = super(UserReregistrationEmailFactory, self).get_context()
+        context['url'] = settings.PASSWORD_RESET_CONFIRM_URL.format(
+            **context
+        )
+        return context
+
+
 class UserConfirmationEmailFactory(UserEmailFactoryBase):
     subject_template_name = 'confirmation_email_subject.txt'
     plain_body_template_name = 'confirmation_email_body.txt'

--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -157,6 +157,20 @@ class UserReregistrationEmailFactory(UserEmailFactoryBase):
         return context
 
 
+class UserReregistrationInactiveEmailFactory(UserEmailFactoryBase):
+    subject_template_name = 'reregistration_email_subject.txt'
+    plain_body_template_name = 'reregistration_inactive_email_body.txt'
+    if settings.USE_HTML_EMAIL_TEMPLATES:
+        html_body_template_name = 'reregistration_inactive_email_body.html'
+
+    def get_context(self):
+        context = super(UserReregistrationInactiveEmailFactory, self).get_context()
+        context['url'] = settings.PASSWORD_RESET_CONFIRM_URL.format(
+            **context
+        )
+        return context
+
+
 class UserConfirmationEmailFactory(UserEmailFactoryBase):
     subject_template_name = 'confirmation_email_subject.txt'
     plain_body_template_name = 'confirmation_email_body.txt'

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -56,6 +56,26 @@ If ``True``, register or activation endpoint will send confirmation email to use
 
 **Default**: ``False``
 
+SEND_REREGISTRATION_EMAIL
+-------------------------
+
+If ``True``, register endpoint will send warning and reminder email to user. 
+Only active users are able to reset their passwords (User.is_active is True).
+The email will ask the User to reset their password since someone is trying to
+re-register their account.
+If User.is_active is False, will send a warning
+
+**Default**: ``False``
+
+REREGISTRATION_SHOW_RESPONSE
+----------------------------
+
+If ``False`` (default), the ``/register/`` endpoint will always return
+a ``HTTP_201_CREATED`` response, as well as the UserSerializer serializer.data response 
+of one of those users, so that it makes it difficult to distinguish if a User has this email
+
+**Default**: ``True``
+
 ACTIVATION_URL
 --------------
 


### PR DESCRIPTION
Changes to address #213 

REREGISTRATION_SHOW_RESPONSE
----------------------------

If ``False`` (default), the ``/register/`` endpoint will always return
a ``HTTP_201_CREATED`` response, as well as the UserSerializer serializer.data response 
of one of those users, so that it makes it difficult to distinguish if a User has this email

**Default**: ``True``

SEND_REREGISTRATION_EMAIL
-------------------------

If ``True``, register endpoint will send warning and reminder email to user. 
Only active users are able to reset their passwords (User.is_active is True).
The email will ask the User to reset their password since someone is trying to
re-register their account.
If User.is_active is False, will send a warning

**Default**: ``False``

Reregistration Email is also different - if the User is_active or not, they will either have the option to reset password or will be reminded to complete activation.