### PR TITLE
Move User.is_active check from database to Python

### DIFF
--- a/djoser/views.py
+++ b/djoser/views.py
@@ -130,11 +130,11 @@ class PasswordResetView(utils.ActionViewMixin, generics.GenericAPIView):
     def get_users(self, email):
         if self._users is None:
             email_field_name = get_user_email_field_name(User)
-            active_users_kwargs = {
-                email_field_name + '__iexact': email, 'is_active': True
+            filter_users_kwargs = {
+                email_field_name + '__iexact': email
             }
-            active_users = User._default_manager.filter(**active_users_kwargs)
-            self._users = [u for u in active_users if u.has_usable_password()]
+            filtered_users = User._default_manager.filter(**filter_users_kwargs)
+            self._users = [u for u in filtered_users if u.is_active and u.has_usable_password()]
         return self._users
 
     def send_password_reset_email(self, user):

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -130,12 +130,12 @@ class PasswordResetView(utils.ActionViewMixin, generics.GenericAPIView):
     def get_users(self, email):
         if self._users is None:
             email_field_name = get_user_email_field_name(User)
-            filter_users_kwargs = {
+            users = User._default_manager.filter(**{
                 email_field_name + '__iexact': email
-            }
-            _users = User._default_manager.filter(**filter_users_kwargs)
-            self._users = [u for u in _users
-                           if u.is_active and u.has_usable_password()]
+            })
+            self._users = [
+                u for u in users if u.is_active and u.has_usable_password()
+            ]
         return self._users
 
     def send_password_reset_email(self, user):

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -133,8 +133,9 @@ class PasswordResetView(utils.ActionViewMixin, generics.GenericAPIView):
             filter_users_kwargs = {
                 email_field_name + '__iexact': email
             }
-            filtered_users = User._default_manager.filter(**filter_users_kwargs)
-            self._users = [u for u in filtered_users if u.is_active and u.has_usable_password()]
+            _users = User._default_manager.filter(**filter_users_kwargs)
+            self._users = [u for u in _users
+                           if u.is_active and u.has_usable_password()]
         return self._users
 
     def send_password_reset_email(self, user):


### PR DESCRIPTION
https://github.com/sunscrapers/djoser/issues/223

Also renamed `active_users_kwargs` to `filter_users_kwargs`, and `active_users` to `filtered_users`, because the "active" word is no longer applicable. Feel free to change these variable names to something else if necessary.