### PR TITLE
Refactored Email into Mixin

### DIFF
--- a/djoser/mixins.py
+++ b/djoser/mixins.py
@@ -1,0 +1,12 @@
+import djoser.email
+
+class ActionViewMixin(object):
+    def post(self, request):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        return self._action(serializer)
+
+
+class EmailMixin(object):
+    def get_email(self):
+        return djoser.email

--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -24,16 +24,3 @@ def logout_user(request):
     user_logged_out.send(
         sender=request.user.__class__, request=request, user=request.user
     )
-
-
-class ActionViewMixin(object):
-    def post(self, request):
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        return self._action(serializer)
-
-
-class EmailMixin(object):
-    def get_email(self):
-        import djoser.email
-        return djoser.email

--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -3,6 +3,7 @@ from django.utils.encoding import force_bytes, force_text
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 
 from djoser.conf import settings
+from djoser import email
 
 
 def encode_uid(pk):
@@ -31,3 +32,8 @@ class ActionViewMixin(object):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         return self._action(serializer)
+
+
+class EmailMixin(object):
+    def get_email(self):
+        return email

--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -3,7 +3,7 @@ from django.utils.encoding import force_bytes, force_text
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 
 from djoser.conf import settings
-from djoser import email
+import djoser.email
 
 
 def encode_uid(pk):
@@ -36,4 +36,4 @@ class ActionViewMixin(object):
 
 class EmailMixin(object):
     def get_email(self):
-        return email
+        return djoser.email

--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -3,7 +3,6 @@ from django.utils.encoding import force_bytes, force_text
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 
 from djoser.conf import settings
-import djoser.email
 
 
 def encode_uid(pk):
@@ -36,4 +35,5 @@ class ActionViewMixin(object):
 
 class EmailMixin(object):
     def get_email(self):
+        import djoser.email
         return djoser.email

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -6,7 +6,7 @@ from rest_framework import generics, permissions, status, views
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
-from djoser import email, utils, signals
+from djoser import utils, signals
 from djoser.compat import get_user_email, get_user_email_field_name
 from djoser.conf import settings
 
@@ -50,7 +50,7 @@ class RootView(views.APIView):
             return []
 
 
-class UserCreateView(generics.CreateAPIView):
+class UserCreateView(generics.CreateAPIView, utils.EmailMixin):
     """
     Use this endpoint to register new user.
     """
@@ -66,9 +66,9 @@ class UserCreateView(generics.CreateAPIView):
         context = {'user': user}
         to = [get_user_email(user)]
         if settings.SEND_ACTIVATION_EMAIL:
-            email.ActivationEmail(self.request, context).send(to)
+            self.get_email().ActivationEmail(self.request, context).send(to)
         elif settings.SEND_CONFIRMATION_EMAIL:
-            email.ConfirmationEmail(self.request, context).send(to)
+            self.get_email().ConfirmationEmail(self.request, context).send(to)
 
 
 class UserDeleteView(generics.CreateAPIView):
@@ -119,7 +119,7 @@ class TokenDestroyView(views.APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class PasswordResetView(utils.ActionViewMixin, generics.GenericAPIView):
+class PasswordResetView(utils.ActionViewMixin, generics.GenericAPIView, utils.EmailMixin):
     """
     Use this endpoint to send email to user with password reset link.
     """
@@ -147,7 +147,7 @@ class PasswordResetView(utils.ActionViewMixin, generics.GenericAPIView):
     def send_password_reset_email(self, user):
         context = {'user': user}
         to = [get_user_email(user)]
-        email.PasswordResetEmail(self.request, context).send(to)
+        self.get_email().PasswordResetEmail(self.request, context).send(to)
 
 
 class SetPasswordView(utils.ActionViewMixin, generics.GenericAPIView):
@@ -189,7 +189,7 @@ class PasswordResetConfirmView(utils.ActionViewMixin, generics.GenericAPIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class ActivationView(utils.ActionViewMixin, generics.GenericAPIView):
+class ActivationView(utils.ActionViewMixin, generics.GenericAPIView, utils.EmailMixin):
     """
     Use this endpoint to activate user account.
     """
@@ -209,12 +209,12 @@ class ActivationView(utils.ActionViewMixin, generics.GenericAPIView):
         if settings.SEND_CONFIRMATION_EMAIL:
             context = {'user': user}
             to = [get_user_email(user)]
-            email.ConfirmationEmail(self.request, context).send(to)
+            self.get_email().ConfirmationEmail(self.request, context).send(to)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class SetUsernameView(utils.ActionViewMixin, generics.GenericAPIView):
+class SetUsernameView(utils.ActionViewMixin, generics.GenericAPIView, utils.EmailMixin):
     """
     Use this endpoint to change user username.
     """
@@ -234,13 +234,13 @@ class SetUsernameView(utils.ActionViewMixin, generics.GenericAPIView):
             user.is_active = False
             context = {'user': user}
             to = [get_user_email(user)]
-            email.ActivationEmail(self.request, context).send(to)
+            self.get_email().ActivationEmail(self.request, context).send(to)
         user.save()
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class UserView(generics.RetrieveUpdateAPIView):
+class UserView(generics.RetrieveUpdateAPIView, utils.EmailMixin):
     """
     Use this endpoint to retrieve/update user.
     """
@@ -257,4 +257,4 @@ class UserView(generics.RetrieveUpdateAPIView):
         if settings.SEND_ACTIVATION_EMAIL and not user.is_active:
             context = {'user': user}
             to = [get_user_email(user)]
-            email.ActivationEmail(self.request, context).send(to)
+            self.get_email().ActivationEmail(self.request, context).send(to)

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -6,7 +6,7 @@ from rest_framework import generics, permissions, status, views
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
-from djoser import utils, signals
+from djoser import mixins, utils, signals
 from djoser.compat import get_user_email, get_user_email_field_name
 from djoser.conf import settings
 
@@ -50,7 +50,7 @@ class RootView(views.APIView):
             return []
 
 
-class UserCreateView(generics.CreateAPIView, utils.EmailMixin):
+class UserCreateView(generics.CreateAPIView, mixins.EmailMixin):
     """
     Use this endpoint to register new user.
     """
@@ -92,7 +92,7 @@ class UserDeleteView(generics.CreateAPIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class TokenCreateView(utils.ActionViewMixin, generics.GenericAPIView):
+class TokenCreateView(mixins.ActionViewMixin, generics.GenericAPIView):
     """
     Use this endpoint to obtain user authentication token.
     """
@@ -119,7 +119,7 @@ class TokenDestroyView(views.APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class PasswordResetView(utils.ActionViewMixin, generics.GenericAPIView, utils.EmailMixin):
+class PasswordResetView(mixins.ActionViewMixin, generics.GenericAPIView, mixins.EmailMixin):
     """
     Use this endpoint to send email to user with password reset link.
     """
@@ -150,7 +150,7 @@ class PasswordResetView(utils.ActionViewMixin, generics.GenericAPIView, utils.Em
         self.get_email().PasswordResetEmail(self.request, context).send(to)
 
 
-class SetPasswordView(utils.ActionViewMixin, generics.GenericAPIView):
+class SetPasswordView(mixins.ActionViewMixin, generics.GenericAPIView):
     """
     Use this endpoint to change user password.
     """
@@ -171,7 +171,7 @@ class SetPasswordView(utils.ActionViewMixin, generics.GenericAPIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class PasswordResetConfirmView(utils.ActionViewMixin, generics.GenericAPIView):
+class PasswordResetConfirmView(mixins.ActionViewMixin, generics.GenericAPIView):
     """
     Use this endpoint to finish reset password process.
     """
@@ -189,7 +189,7 @@ class PasswordResetConfirmView(utils.ActionViewMixin, generics.GenericAPIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class ActivationView(utils.ActionViewMixin, generics.GenericAPIView, utils.EmailMixin):
+class ActivationView(mixins.ActionViewMixin, generics.GenericAPIView, mixins.EmailMixin):
     """
     Use this endpoint to activate user account.
     """
@@ -214,7 +214,7 @@ class ActivationView(utils.ActionViewMixin, generics.GenericAPIView, utils.Email
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class SetUsernameView(utils.ActionViewMixin, generics.GenericAPIView, utils.EmailMixin):
+class SetUsernameView(mixins.ActionViewMixin, generics.GenericAPIView, mixins.EmailMixin):
     """
     Use this endpoint to change user username.
     """
@@ -240,7 +240,7 @@ class SetUsernameView(utils.ActionViewMixin, generics.GenericAPIView, utils.Emai
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class UserView(generics.RetrieveUpdateAPIView, utils.EmailMixin):
+class UserView(generics.RetrieveUpdateAPIView, mixins.EmailMixin):
     """
     Use this endpoint to retrieve/update user.
     """


### PR DESCRIPTION
Refactored email into a mixin so it can easily be overridden. Currently a lot of methods in views need to be overridden just to replace the email template and such. This abstracts out the email functionality to be easily modifiable.

Subclass the view and override `get_email(self):` with your own email.py