### PR TITLE
Raise AuthenticationFailed instead of ValidationError.

### DIFF
--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -109,6 +109,12 @@ class TokenCreateSerializer(serializers.Serializer):
     def _validate_user_is_active(self, user):
         if not user.is_active:
             self.fail('inactive_account')
+    
+    def fail(self, key, **kwargs):
+        try:
+            super(TokenCreateSerializer, self).fail(key, **kwargs)
+        except exceptions.ValidationError as error:
+            raise exceptions.AuthenticationFailed(error.detail)
 
 
 class PasswordResetSerializer(serializers.Serializer):


### PR DESCRIPTION
Currently, failure to authenticate a username/password to issue a token results in a 400 Bad Request status code. I think that a 401 Unauthorized response makes more sense in this context. To return the desired status code, I overrode ````self.fail```` to raise an AuthenticationFailed exception.