### PR TITLE
Fix validation: keep original ValidationError

### DIFF
--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -47,16 +47,9 @@ class UserCreateSerializer(serializers.ModelSerializer):
             User.USERNAME_FIELD, User._meta.pk.name, 'password',
         )
 
-    def validate(self, attrs):
-        user = User(**attrs)
-        password = attrs.get('password')
-
-        try:
-            validate_password(password, user)
-        except django_exceptions.ValidationError as e:
-            raise serializers.ValidationError({'password': list(e.messages)})
-
-        return attrs
+    def validate_password(self, value):
+        validate_password(value)
+        return value
 
     def create(self, validated_data):
         try:
@@ -166,17 +159,11 @@ class ActivationSerializer(UidAndTokenSerializer):
 class PasswordSerializer(serializers.Serializer):
     new_password = serializers.CharField(style={'input_type': 'password'})
 
-    def validate(self, attrs):
+    def validate_new_password(self, value):
         user = self.context['request'].user or self.user
         assert user is not None
-
-        try:
-            validate_password(attrs['new_password'], user)
-        except django_exceptions.ValidationError as e:
-            raise serializers.ValidationError({
-                'new_password': list(e.messages)
-            })
-        return super(PasswordSerializer, self).validate(attrs)
+        validate_password(value, user)
+        return value
 
 
 class PasswordRetypeSerializer(PasswordSerializer):


### PR DESCRIPTION
The casting into serializers.ValidationError was losing the code(s) etc,
and Django's ValidationError should get handled correctly by DRF.

TODO:
 - [ ] (adjust?) test(s)