### PR TITLE
Make trailing slash optional on all endpoints

### DIFF
--- a/djoser/urls/authtoken.py
+++ b/djoser/urls/authtoken.py
@@ -5,12 +5,12 @@ from djoser import views
 
 urlpatterns = [
     url(
-        r'^token/create/$',
+        r'^token/create[/]$',
         views.TokenCreateView.as_view(),
         name='token-create'
     ),
     url(
-        r'^token/destroy/$',
+        r'^token/destroy[/]$',
         views.TokenDestroyView.as_view(),
         name='token-destroy'
     ),

--- a/djoser/urls/authtoken.py
+++ b/djoser/urls/authtoken.py
@@ -5,12 +5,12 @@ from djoser import views
 
 urlpatterns = [
     url(
-        r'^token/create[/]$',
+        r'^token/create/?$',
         views.TokenCreateView.as_view(),
         name='token-create'
     ),
     url(
-        r'^token/destroy[/]$',
+        r'^token/destroy/?$',
         views.TokenDestroyView.as_view(),
         name='token-destroy'
     ),

--- a/djoser/urls/base.py
+++ b/djoser/urls/base.py
@@ -7,35 +7,35 @@ User = get_user_model()
 
 
 urlpatterns = [
-    url(r'^me[/]$', views.UserView.as_view(), name='user'),
+    url(r'^me/?$', views.UserView.as_view(), name='user'),
     url(
-        r'^users/create[/]$',
+        r'^users/create/?$',
         views.UserCreateView.as_view(),
         name='user-create'
     ),
     url(
-        r'^users/delete[/]$',
+        r'^users/delete/?$',
         views.UserDeleteView.as_view(),
         name='user-delete'
     ),
     url(
-        r'^users/activate[/]$',
+        r'^users/activate/?$',
         views.ActivationView.as_view(),
         name='user-activate'
     ),
     url(
-        r'^{0}[/]$'.format(User.USERNAME_FIELD),
+        r'^{0}/?$'.format(User.USERNAME_FIELD),
         views.SetUsernameView.as_view(),
         name='set_username'
     ),
-    url(r'^password[/]$', views.SetPasswordView.as_view(), name='set_password'),
+    url(r'^password/?$', views.SetPasswordView.as_view(), name='set_password'),
     url(
-        r'^password/reset[/]$',
+        r'^password/reset/?$',
         views.PasswordResetView.as_view(),
         name='password_reset'
     ),
     url(
-        r'^password/reset/confirm[/]$',
+        r'^password/reset/confirm/?$',
         views.PasswordResetConfirmView.as_view(),
         name='password_reset_confirm'
     ),

--- a/djoser/urls/base.py
+++ b/djoser/urls/base.py
@@ -7,35 +7,35 @@ User = get_user_model()
 
 
 urlpatterns = [
-    url(r'^me/$', views.UserView.as_view(), name='user'),
+    url(r'^me[/]$', views.UserView.as_view(), name='user'),
     url(
-        r'^users/create/$',
+        r'^users/create[/]$',
         views.UserCreateView.as_view(),
         name='user-create'
     ),
     url(
-        r'^users/delete/$',
+        r'^users/delete[/]$',
         views.UserDeleteView.as_view(),
         name='user-delete'
     ),
     url(
-        r'^users/activate/$',
+        r'^users/activate[/]$',
         views.ActivationView.as_view(),
         name='user-activate'
     ),
     url(
-        r'^{0}/$'.format(User.USERNAME_FIELD),
+        r'^{0}[/]$'.format(User.USERNAME_FIELD),
         views.SetUsernameView.as_view(),
         name='set_username'
     ),
-    url(r'^password/$', views.SetPasswordView.as_view(), name='set_password'),
+    url(r'^password[/]$', views.SetPasswordView.as_view(), name='set_password'),
     url(
-        r'^password/reset/$',
+        r'^password/reset[/]$',
         views.PasswordResetView.as_view(),
         name='password_reset'
     ),
     url(
-        r'^password/reset/confirm/$',
+        r'^password/reset/confirm[/]$',
         views.PasswordResetConfirmView.as_view(),
         name='password_reset_confirm'
     ),

--- a/djoser/urls/jwt.py
+++ b/djoser/urls/jwt.py
@@ -4,7 +4,7 @@ from rest_framework_jwt import views
 
 
 urlpatterns = [
-    url(r'^jwt/create[/]', views.obtain_jwt_token, name='jwt-create'),
-    url(r'^jwt/refresh[/]', views.refresh_jwt_token, name='jwt-refresh'),
-    url(r'^jwt/verify[/]', views.verify_jwt_token, name='jwt-verify'),
+    url(r'^jwt/create/?', views.obtain_jwt_token, name='jwt-create'),
+    url(r'^jwt/refresh/?', views.refresh_jwt_token, name='jwt-refresh'),
+    url(r'^jwt/verify/?', views.verify_jwt_token, name='jwt-verify'),
 ]

--- a/djoser/urls/jwt.py
+++ b/djoser/urls/jwt.py
@@ -4,7 +4,7 @@ from rest_framework_jwt import views
 
 
 urlpatterns = [
-    url(r'^jwt/create/', views.obtain_jwt_token, name='jwt-create'),
-    url(r'^jwt/refresh/', views.refresh_jwt_token, name='jwt-refresh'),
-    url(r'^jwt/verify/', views.verify_jwt_token, name='jwt-verify'),
+    url(r'^jwt/create[/]', views.obtain_jwt_token, name='jwt-create'),
+    url(r'^jwt/refresh[/]', views.refresh_jwt_token, name='jwt-refresh'),
+    url(r'^jwt/verify[/]', views.verify_jwt_token, name='jwt-verify'),
 ]

--- a/docs/source/migration_guide.rst
+++ b/docs/source/migration_guide.rst
@@ -50,7 +50,7 @@ are very helpful in the process.
 Some View class names and URLs has been updated
 -----------------------------------------------
 
-Also please note that for sake of consistency all URLs now end with a trailing slash.
+Also please note that for sake of consistency all URLs now end with a trailing slash. The trailing slash is optional to ensure compatibility with frontend tools that strip the trailing slash (eg Google's Chrome browser and Angular framework).
 
 View class names:
 


### PR DESCRIPTION
Hi guys, your library isn't compatible with any frontend tools that strip trailing slashes from endpoints before making requests. This unfortunately means many Google tools, including Angular and most importantly, Chrome/Chromium. If you need to make `POST` requests to any of the endpoints, Django's `APPEND_SLASH` won't work as you lose the payload during the redirect.

This (minimal) pull request changes the regex to make the trailing slash optional on all of the urls.