### PR TITLE
Update example with working password

### DIFF
--- a/docs/source/sample_usage.rst
+++ b/docs/source/sample_usage.rst
@@ -28,7 +28,7 @@ Register a new user:
 
 .. code-block:: text
 
-    $ curl -X POST http://127.0.0.1:8088/auth/users/ --data 'username=djoser&password=djoser'
+    $ curl -X POST http://127.0.0.1:8088/auth/users/ --data 'username=djoser&password=alpine12'
     {"email": "", "username": "djoser", "id":1}
 
 So far, so good. We have just created a new user using REST API.

--- a/docs/source/sample_usage.rst
+++ b/docs/source/sample_usage.rst
@@ -37,7 +37,7 @@ Let's access user's details:
 
 .. code-block:: text
 
-    $ curl -X GET http://127.0.0.1:8088/auth/users/me/
+    $ curl -LX GET http://127.0.0.1:8088/auth/users/me/
     {"detail": "Authentication credentials were not provided."}
 
 As we can see, we cannot access user profile without logging in. Pretty obvious.
@@ -46,7 +46,7 @@ Let's log in:
 
 .. code-block:: text
 
-    curl -X POST http://127.0.0.1:8088/auth/token/login/ --data 'username=djoser&password=djoser'
+    curl -X POST http://127.0.0.1:8088/auth/token/login/ --data 'username=djoser&password=alpine12'
     {"auth_token": "b704c9fc3655635646356ac2950269f352ea1139"}
 
 We have just obtained an authorization token that we may use later in order to retrieve specific resources.
@@ -55,14 +55,14 @@ Let's access user's details again:
 
 .. code-block:: text
 
-    $ curl -X GET http://127.0.0.1:8088/auth/users/me/
+    $ curl -LX GET http://127.0.0.1:8088/auth/users/me/
     {"detail": "Authentication credentials were not provided."}
 
 Access is still forbidden but let's offer the token we obtained:
 
 .. code-block:: text
 
-    $ curl -X GET http://127.0.0.1:8088/auth/users/me/ -H 'Authorization: Token b704c9fc3655635646356ac2950269f352ea1139'
+    $ curl -LX GET http://127.0.0.1:8088/auth/users/me/ -H 'Authorization: Token b704c9fc3655635646356ac2950269f352ea1139'
     {"email": "", "username": "djoser", "id": 1}
 
 Yay, it works!
@@ -77,7 +77,7 @@ And try access user profile again:
 
 .. code-block:: text
 
-    $ curl -X GET http://127.0.0.1:8088/auth/users/me/ -H 'Authorization: Token b704c9fc3655635646356ac2950269f352ea1139'
+    $ curl -LX GET http://127.0.0.1:8088/auth/users/me/ -H 'Authorization: Token b704c9fc3655635646356ac2950269f352ea1139'
     {"detail": "Invalid token"}
 
 As we can see, user has been logged out successfully and the proper token has been removed.


### PR DESCRIPTION
Using the username/password provided, djoser throws the following error:

```
{"password":["The password is too similar to the username.","This password is too short. It must contain at least 8 characters."]}
```

The first logical change is to just use `password` for the password, but that errors with

```
{"password":["This password is too common."]}
```

The change I've proposed (`alpine12`) works with no issues.

**Note** - I'm not sure which branch to PR, project maintainers feel free to change the base branch or request that I do so.