### PR TITLE
Split user serializers (fix #294)

### DIFF
--- a/djoser/conf.py
+++ b/djoser/conf.py
@@ -55,6 +55,8 @@ default_settings = {
             'djoser.serializers.UserDeleteSerializer',
         'user':
             'djoser.serializers.UserSerializer',
+        'current_user':
+            'djoser.serializers.CurrentUserSerializer',
         'token':
             'djoser.serializers.TokenSerializer',
         'token_create':

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.password_validation import validate_password
 from django.core import exceptions as django_exceptions
@@ -31,8 +33,21 @@ class UserSerializer(serializers.ModelSerializer):
         return super(UserSerializer, self).update(instance, validated_data)
 
 
-class CurrentUserSerializer(UserSerializer):
-    pass
+class CurrentUserSerializer(settings.SERIALIZERS.user):
+    def __init__(self, *args, **kwargs):
+        # Warn user about serializer split
+        warnings.simplefilter('default')
+        warnings.warn(
+            (
+                'Current user endpoints now use their own serializer setting. '
+                'For more information, see: '
+                'https://djoser.readthedocs.io/en/latest/settings.html#serializers'  # noqa
+            ),
+            DeprecationWarning,
+        )
+
+        # Perform regular init actions
+        super(CurrentUserSerializer, self).__init__(*args, **kwargs)
 
 
 class UserCreateSerializer(serializers.ModelSerializer):

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -31,6 +31,10 @@ class UserSerializer(serializers.ModelSerializer):
         return super(UserSerializer, self).update(instance, validated_data)
 
 
+class CurrentUserSerializer(UserSerializer):
+    pass
+
+
 class UserCreateSerializer(serializers.ModelSerializer):
     password = serializers.CharField(
         style={'input_type': 'password'},

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -283,19 +283,28 @@ class UserViewSet(UserCreateView, viewsets.ModelViewSet):
         return super(UserViewSet, self).get_permissions()
 
     def get_serializer_class(self):
+        if self.action == 'me':
+            # Use the current user serializer on 'me' endpoints
+            self.serializer_class = settings.SERIALIZERS.current_user
+
         if self.action == 'create':
             return settings.SERIALIZERS.user_create
+
         elif self.action == 'remove' or (
                 self.action == 'me' and self.request and
                 self.request.method == 'DELETE'
         ):
             return settings.SERIALIZERS.user_delete
+
         elif self.action == 'confirm':
             return settings.SERIALIZERS.activation
+
         elif self.action == 'change_username':
             if settings.SET_USERNAME_RETYPE:
                 return settings.SERIALIZERS.set_username_retype
+
             return settings.SERIALIZERS.set_username
+
         return self.serializer_class
 
     def get_instance(self):

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -143,6 +143,7 @@ to update the defaults, so by providing, e.g. one key, all the others will stay 
         'user_create': 'djoser.serializers.UserCreateSerializer',
         'user_delete': 'djoser.serializers.UserDeleteSerializer',
         'user': 'djoser.serializers.UserSerializer',
+        'current_user': 'djoser.serializers.CurrentUserSerializer',
         'token': 'djoser.serializers.TokenSerializer',
         'token_create': 'djoser.serializers.TokenCreateSerializer',
     }

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -119,6 +119,14 @@ Dictionary which maps djoser serializer names to paths to serializer classes.
 This setting provides a way to easily override given serializer(s) - it's is used
 to update the defaults, so by providing, e.g. one key, all the others will stay default.
 
+.. note::
+
+    Current user endpoints now use the serializer specified by
+    ``SERIALIZERS.current_user``. This enables better security and privacy:
+    the serializers can be configured separately so that confidential fields
+    that are returned to the current user are not shown in the regular user
+    endpoints.
+
 **Examples**
 
 .. code-block:: python

--- a/testproject/testapp/tests/test_user_view.py
+++ b/testproject/testapp/tests/test_user_view.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test.utils import override_settings
 
+import pytest
 from djet import assertions, restframework, utils
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -69,6 +70,10 @@ class UserViewSetMeTest(APITestCase,
     def setUp(self):
         self.user = create_user()
         self.client.force_authenticate(user=self.user)
+
+    def test_deprecation_warning(self):
+        with pytest.deprecated_call():
+            self.client.get(reverse('user-me'))
 
     def test_get_return_user(self):
         response = self.client.get(reverse('user-me'))


### PR DESCRIPTION
This adds a new option `current_user` to `settings.SERIALIZERS` that allows different information to be returned from 'me' endpoints.

Currently a work in progress. See #294.