### PR TITLE
views: use @action(detail=False) instead of deprecated @list_route

### DIFF
--- a/djoser/views.py
+++ b/djoser/views.py
@@ -3,7 +3,7 @@ from django.contrib.auth.tokens import default_token_generator
 from django.urls.exceptions import NoReverseMatch
 from django.utils.timezone import now
 from rest_framework import generics, permissions, status, views, viewsets
-from rest_framework.decorators import list_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
@@ -333,7 +333,7 @@ class UserViewSet(UserCreateView, viewsets.ModelViewSet):
         self.perform_destroy(instance)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    @list_route(['get', 'put', 'patch', 'delete'])
+    @action(['get', 'put', 'patch', 'delete'], detail=False)
     def me(self, request, *args, **kwargs):
         self.get_object = self.get_instance
         if request.method == 'GET':
@@ -345,7 +345,7 @@ class UserViewSet(UserCreateView, viewsets.ModelViewSet):
         elif request.method == 'DELETE':
             return self.destroy(request, *args, **kwargs)
 
-    @list_route(['post'])
+    @action(['post'], detail=False)
     def confirm(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -364,7 +364,7 @@ class UserViewSet(UserCreateView, viewsets.ModelViewSet):
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    @list_route(['post'])
+    @action(['post'], detail=False)
     def change_username(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
Fixes:

> …/djoser/views.py:336: PendingDeprecationWarning:
> `list_route` is pending deprecation and will be removed in 3.10 in
> favor of `action`, which accepts a `detail` bool. Use `@action(detail=False)`
> instead.

Have not checked if it works with all supported DRF versions, but CI should tell us.