### PR TITLE
[fix] allow update only current request user in UserViewSet

### DIFF
--- a/djoser/permissions.py
+++ b/djoser/permissions.py
@@ -1,0 +1,7 @@
+from rest_framework import permissions
+
+
+class CurrentUserOrAdmin(permissions.IsAuthenticated):
+    def has_object_permission(self, request, view, obj):
+        user = request.user
+        return user.is_staff or obj.pk == user.pk

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -10,6 +10,7 @@ from rest_framework.reverse import reverse
 from djoser import utils, signals
 from djoser.compat import get_user_email, get_user_email_field_name
 from djoser.conf import settings
+from djoser.permissions import CurrentUserOrAdmin
 
 User = get_user_model()
 
@@ -275,7 +276,7 @@ class UserView(generics.RetrieveUpdateAPIView):
 class UserViewSet(UserCreateView, viewsets.ModelViewSet):
     serializer_class = settings.SERIALIZERS.user
     queryset = User.objects.all()
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [CurrentUserOrAdmin]
     token_generator = default_token_generator
 
     def get_permissions(self):


### PR DESCRIPTION
#303

default permission class in the `UserViewSet` allows any authenticated user to patch other `User` instances. I switched it to check object against request user.