### PR TITLE
Update Travis testing for newer versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+sudo: required
+dist: xenial
 
 language: python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 python:
   - "3.5"
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
 
 env:
   - DJANGO=1.11
@@ -19,7 +19,7 @@ matrix:
     - python: "3.4"
       env: DJANGO=1.11
   exclude:
-    - python: "3.7-dev"
+    - python: "3.7"
       env: DJANGO=1.11
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,11 @@
 sudo: false
 
 language: python
+
 python:
   - "3.5"
   - "3.6"
   - "3.7"
-
-env:
-  - DJANGO=1.11
-  - DJANGO=2.0
-  - DJANGO=2.1
-
-matrix:
-  fast_finish: true
-  include:
-    - python: "2.7"
-      env: DJANGO=1.11
-    - python: "3.4"
-      env: DJANGO=1.11
-  exclude:
-    - python: "3.7"
-      env: DJANGO=1.11
 
 install:
   - travis_retry pip install -U tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ dist: xenial
 language: python
 
 python:
+  - "2.7"
+  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ To be able to run **djoser** you have to meet following requirements:
 
 - Python (2.7, 3.4, 3.5, 3.6)
 - Django (1.11, 2.0, 2.1)
-- Django REST Framework (3.7, 3.8)
+- Django REST Framework (3.7, 3.8, 3.9)
 
 Bear in mind that for Django-2.x you will need at least Python 3.5
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,14 +5,6 @@ envlist =
     py{35,36,37}-django21-drf38
     flake8
 
-
-[travis:env]
-DJANGO =
-    1.11: django111
-    2.0: django20
-    2.1: django21
-
-
 [testenv]
 passenv = HOME CI TRAVIS TRAVIS_*
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{27,34,35,36}-django111-drf{37,38}
-    py{35,36,37}-django20-drf38
-    py{35,36,37}-django21-drf38
+    py{27,34,35,36}-django111-drf{37,38,39}
+    py{35,36,37}-django20-drf(38,39}
+    py{35,36,37}-django21-drf(38,39}
     flake8
 
 [testenv]
@@ -19,6 +19,7 @@ deps =
     django20: django>=2.0,<2.1
     drf37: djangorestframework>=3.7,<3.8
     drf38: djangorestframework>=3.8,<3.9
+    drf39: djangorestframework>=3.9,<3.10
     py27: mock
     -rrequirements.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     py{27,34,35,36}-django111-drf{37,38,39}
-    py{35,36,37}-django20-drf(38,39}
-    py{35,36,37}-django21-drf(38,39}
+    py{35,36,37}-django20-drf{38,39}
+    py{35,36,37}-django21-drf{38,39}
     flake8
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{27,34,35,36}-django111-drf{37,38,39}
-    py{35,36,37}-django20-drf{38,39}
+    py{35,36,37}-django20-drf{37,38,39}
     py{35,36,37}-django21-drf{38,39}
     flake8
 


### PR DESCRIPTION
- [x] Switch to 3.7 from 3.7-dev
- [x] Control Django versions tested through Tox configuration
- [x] Add testing for DRF 3.9
- [x] Sync Python versions tested to match README
- [x] Sync DRF versions tested to match README