### PR TITLE
Added the social auth workflow

### DIFF
--- a/docs/source/social_endpoints.rst
+++ b/docs/source/social_endpoints.rst
@@ -8,10 +8,26 @@ Social Endpoints
 Provider Auth
 -------------
 
-Use this endpoint to obtain authorization URL for a given provider with the
-GET method or to obtain authentication token with POST method. List of providers
-is available at
+Using these endpoints you can authenticate with external tools.
+
+The workflow should look like this:
+
+1. Access the endpoint providing a ``redirect_uri`` that would perform the
+   ``POST`` action later.
+2. The request would return a JSON containing one key ``authorization_url``.
+   Redirect the user to that URL.
+3. When the user authenticates with the external tool, that tool would redirect
+   them to the ``redirect_uri`` you provided with a ``GET`` querystring
+   containing two arguments: ``code`` and ``state``
+4. From the view that your user got redirected to, issue a ``POST`` request
+   to the endpoint with the ``code`` and ``state`` arguments. You should use
+   ``application/x-www-form-urlencoded`` not JSON.  The user should be now
+   authenticated in your application.
+   
+The list of providers is available at
 `social backend docs <https://python-social-auth.readthedocs.io/en/latest/backends/index.html#social-backends>`_.
+please follow the instructions provided there to configure your backend.
+
 
 **Default URL**: ``/o/{{ provider }}/``
 


### PR DESCRIPTION
The proper usage of social auth endpoints was confusing. The full
workflow is now described in the documentation.

Fixes: #317 