### PR TITLE
Added the resend activation e-mail endpoint

### DIFF
--- a/djoser/urls/base.py
+++ b/djoser/urls/base.py
@@ -28,6 +28,11 @@ urlpatterns = [
         name='user-activate'
     ),
     url(
+        r'^users/resend/?$',
+        views.ResendActivationView.as_view(),
+        name='user-activate-resend'
+    ),
+    url(
         r'^{0}/?$'.format(User.USERNAME_FIELD),
         views.SetUsernameView.as_view(),
         name='set_username'

--- a/docs/source/base_endpoints.rst
+++ b/docs/source/base_endpoints.rst
@@ -98,6 +98,23 @@ request to activate endpoint.
 |          | * ``token``    |                                  |
 +----------+----------------+----------------------------------+
 
+User Resend Activation E-mail
+------------------------------
+
+Use this endpoint to re-send the activation e-mail. Note that no e-mail would
+be sent if the user is already active or if they don't have a usable password.
+Also if the sending of activation e-mails is disabled in settings, this call
+will result in ``HTTP_400_BAD_REQUEST``
+
+**Default URL**: ``/users/resend/``
+
++----------+----------------+----------------------------------+
+| Method   | Request        | Response                         |
++==========+================+==================================+
+| ``POST`` | * ``uid``      | ``HTTP_204_NO_CONTENT``          |
+|          |                | ``HTTP_400_BAD_REQUEST``         |
++----------+----------------+----------------------------------+
+
 Set Username
 ------------
 


### PR DESCRIPTION
The resend activation e-mail view that was provided by @sargo was added with documentation and tests.

Fixes: #168 