### PR TITLE
Remove spurious test of active user

### DIFF
--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -121,16 +121,11 @@ class TokenCreateSerializer(serializers.Serializer):
         )
 
         self._validate_user_exists(self.user)
-        self._validate_user_is_active(self.user)
         return attrs
 
     def _validate_user_exists(self, user):
         if not user:
             self.fail('invalid_credentials')
-
-    def _validate_user_is_active(self, user):
-        if not user.is_active:
-            self.fail('inactive_account')
 
 
 class PasswordResetSerializer(serializers.Serializer):


### PR DESCRIPTION
After django==1.8 the authenticate method tests if user is active, so we
can drop the spurious test from djoser.

Fixes: #232 