### PR TITLE
The url value on the template should take it as it is.

### DIFF
--- a/djoser/templates/email/activation.html
+++ b/djoser/templates/email/activation.html
@@ -8,7 +8,7 @@
 {% blocktrans %}You're receiving this email because you need to finish activation process on {{ site_name }}.{% endblocktrans %}
 
 {% trans "Please go to the following page to activate account:" %}
-{{ protocol }}://{{ domain }}/{{ url }}
+{{ protocol }}://{{ domain }}/{{ url|safe }}
 
 {% trans "Thanks for using our site!" %}
 
@@ -20,7 +20,7 @@
 <p>You're receiving this email because you need to finish activation process on {{ site_name }}.</p>{% endblocktrans %}
 
 <p>{% trans "Please go to the following page to activate account:" %}</p>
-<p><a href="{{ protocol }}://{{ domain }}/{{ url }}">{{ protocol }}://{{ domain }}/{{ url }}</a></p>
+<p><a href="{{ protocol }}://{{ domain }}/{{ url|safe }}">{{ protocol }}://{{ domain }}/{{ url|safe }}</a></p>
 
 <p>{% trans "Thanks for using our site!" %}</p>
 


### PR DESCRIPTION
A lot of JS fronend Framworks use & in the url. This leads to incorrect url that djoser sends to frontend.
Related Stackoverflow question https://stackoverflow.com/q/54797037/7986808

The answer we get with the following configuration:
`'ACTIVATION_URL': 'activate?id={uid}\u0026token={token}',`
Aswell as 
`'ACTIVATION_URL': 'activate?id={uid}&token={token}',`
```
Content-Type: multipart/alternative; boundary="===============2108040283=="
MIME-Version: 1.0
Subject: Account activation on l2Store
From: webmaster@localhost
To: aasddda@adasda.ur
Date: Thu, 21 Feb 2019 01:09:16 -0000
Message-ID: <155071135693.93536.10606728533257486545@khashashin.fritz.box>

--===============2108040283==
Content-Type: text/plain; charset="utf-8"
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit

You're receiving this email because you need to finish activation process on l2Store.

Please go to the following page to activate account:
http://localhost:4200/activate?id=MzA&amp;token=541-49140f5abbcf44bf974c

Thanks for using our site!

The l2Store team
--===============2108040283==
Content-Type: text/html; charset="utf-8"
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit

<p>You're receiving this email because you need to finish activation process on l2Store.</p>

<p>Please go to the following page to activate account:</p>
<p><a href="http://localhost:4200/activate?id=MzA&amp;token=541-49140f5abbcf44bf974c">http://localhost:4200/activate?id=MzA&amp;token=541-49140f5abbcf44bf974c</a></p>

<p>Thanks for using our site!</p>

<p>The l2Store team</p>
--===============2108040283==--
```