### PR TITLE
Remove non_field_error from base endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ This document records all notable changes to djoser.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 ---------------------
-`1.6.0`_ (2019-04-02)
+`1.6.0`_ (2019-05-15)
 ---------------------
 
 * Added Russian translation (@ozeranskiy)

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -6,6 +6,7 @@ from django.core import exceptions as django_exceptions
 from django.db import IntegrityError, transaction
 
 from rest_framework import exceptions, serializers
+from rest_framework.exceptions import ValidationError
 
 from djoser import constants, utils
 from djoser.compat import get_user_email, get_user_email_field_name
@@ -167,7 +168,8 @@ class UidAndTokenSerializer(serializers.Serializer):
         if is_token_valid:
             return attrs
         else:
-            self.fail('invalid_token')
+            key_error = 'invalid_token'
+            raise ValidationError({'token': [self.error_messages[key_error]]}, code=key_error)
 
 
 class ActivationSerializer(UidAndTokenSerializer):

--- a/docs/source/base_endpoints.rst
+++ b/docs/source/base_endpoints.rst
@@ -23,6 +23,10 @@ Use this endpoint to retrieve/update user.
 |          |                                | * ``{{ User.USERNAME_FIELD }}``  |
 |          |                                | * ``{{ User._meta.pk.name }}``   |
 |          |                                | * ``{{ User.REQUIRED_FIELDS }}`` |
+|          |                                |                                  |
+|          |                                | ``HTTP_400_BAD_REQUEST``         |
+|          |                                |                                  |
+|          |                                | * ``{{ User.REQUIRED_FIELDS }}`` |
 +----------+--------------------------------+----------------------------------+
 
 User Create
@@ -45,6 +49,12 @@ fields.
 |          | * ``password``                    | * ``{{ User.USERNAME_FIELD }}``  |
 |          |                                   | * ``{{ User._meta.pk.name }}``   |
 |          |                                   | * ``{{ User.REQUIRED_FIELDS }}`` |
+|          |                                   |                                  |
+|          |                                   | ``HTTP_400_BAD_REQUEST``         |
+|          |                                   |                                  |
+|          |                                   | * ``{{ User.USERNAME_FIELD }}``  |
+|          |                                   | * ``{{ User.REQUIRED_FIELDS }}`` |
+|          |                                   | * ``password``                   |
 +----------+-----------------------------------+----------------------------------+
 
 User Delete
@@ -56,6 +66,7 @@ based authentication is used and invoke delete for a given ``User`` instance.
 One of ways to customize the delete behavior is to override ``User.delete``.
 
 **Default URL**: ``/users/me/``
+**Backward-compatible URL**: ``/users/delete/``
 
 +------------+---------------------------------+----------------------------------+
 | Method     |  Request                        | Response                         |
@@ -67,26 +78,14 @@ One of ways to customize the delete behavior is to override ``User.delete``.
 |            |                                 | * ``current_password``           |
 +------------+---------------------------------+----------------------------------+
 
-**Backward-compatible URL**: ``/users/delete/``
-
-+----------+-----------------------------------+----------------------------------+
-| Method   |  Request                          | Response                         |
-+==========+===================================+==================================+
-| ``POST`` | * ``current_password``            | ``HTTP_204_NO_CONTENT``          |
-|          |                                   |                                  |
-|          |                                   | ``HTTP_400_BAD_REQUEST``         |
-|          |                                   |                                  |
-|          |                                   | * ``current_password``           |
-+----------+-----------------------------------+----------------------------------+
-
-
 User Activate
 -------------
 
 Use this endpoint to activate user account. This endpoint is not a URL which
 will be directly exposed to your users - you should provide site in your
 frontend application (configured by ``ACTIVATION_URL``) which will send ``POST``
-request to activate endpoint.
+request to activate endpoint. ``HTTP_403_FORBIDDEN`` will be raised if user is already
+active when calling this endpoint (this will happen if you call it more than once).
 
 **Default URL**: ``/users/confirm/``
 **Backward-compatible URL**: ``/users/activate/``
@@ -94,8 +93,16 @@ request to activate endpoint.
 +----------+--------------------------------------+----------------------------------+
 | Method   | Request                              | Response                         |
 +==========+======================================+==================================+
-| ``POST`` | * ``{{ User.USERNAME_FIELD }}``      | ``HTTP_204_NO_CONTENT``          |
+| ``POST`` | * ``uid``                            | ``HTTP_204_NO_CONTENT``          |
 |          | * ``token``                          |                                  |
+|          |                                      | ``HTTP_400_BAD_REQUEST``         |
+|          |                                      |                                  |
+|          |                                      | * ``uid``                        |
+|          |                                      | * ``non_field_errors``           |
+|          |                                      |                                  |
+|          |                                      | ``HTTP_403_FORBIDDEN``           |
+|          |                                      |                                  |
+|          |                                      | * ``detail``                     |
 +----------+--------------------------------------+----------------------------------+
 
 User Resend Activation E-mail
@@ -111,7 +118,7 @@ will result in ``HTTP_400_BAD_REQUEST``
 +----------+--------------------------------------+----------------------------------+
 | Method   | Request                              | Response                         |
 +==========+======================================+==================================+
-| ``POST`` | * ``{{ User.USERNAME_FIELD }}``      | ``HTTP_204_NO_CONTENT``          |
+| ``POST`` | * ``email``                          | ``HTTP_204_NO_CONTENT``          |
 |          |                                      | ``HTTP_400_BAD_REQUEST``         |
 +----------+--------------------------------------+----------------------------------+
 
@@ -127,13 +134,17 @@ Use this endpoint to change user username (``USERNAME_FIELD``).
 
     ``re_new_{{ User.USERNAME_FIELD }}`` is only required if ``SET_USERNAME_RETYPE`` is ``True``
 
-+----------+----------------------------------------+--------------------------------------+
-| Method   | Request                                | Response                             |
-+==========+========================================+======================================+
-| ``POST`` | * ``new_{{ User.USERNAME_FIELD }}``    | ``HTTP_204_NO_CONTENT``              |
-|          | * ``re_new_{{ User.USERNAME_FIELD }}`` |                                      |
-|          | * ``current_password``                 |                                      |
-+----------+----------------------------------------+--------------------------------------+
++----------+----------------------------------------+-------------------------------------------+
+| Method   | Request                                | Response                                  |
++==========+========================================+===========================================+
+| ``POST`` | * ``new_{{ User.USERNAME_FIELD }}``    | ``HTTP_204_NO_CONTENT``                   |
+|          | * ``re_new_{{ User.USERNAME_FIELD }}`` |                                           |
+|          | * ``current_password``                 | ``HTTP_400_BAD_REQUEST``                  |
+|          |                                        |                                           |
+|          |                                        | * ``new_{{ User.USERNAME_FIELD }}``       |
+|          |                                        | * ``re_new_{{ User.USERNAME_FIELD }}``    |
+|          |                                        | * ``current_password``                    |
++----------+----------------------------------------+-------------------------------------------+
 
 Set Password
 ------------
@@ -146,13 +157,17 @@ Use this endpoint to change user password.
 
     ``re_new_password`` is only required if ``SET_PASSWORD_RETYPE`` is ``True``
 
-+----------+------------------------+--------------------------------------+
-| Method   | Request                | Response                             |
-+==========+========================+======================================+
-| ``POST`` | * ``new_password``     | ``HTTP_204_NO_CONTENT``              |
-|          | * ``re_new_password``  |                                      |
-|          | * ``current_password`` |                                      |
-+----------+------------------------+--------------------------------------+
++----------+------------------------+-------------------------------------------+
+| Method   | Request                | Response                                  |
++==========+========================+===========================================+
+| ``POST`` | * ``new_password``     | ``HTTP_204_NO_CONTENT``                   |
+|          | * ``re_new_password``  |                                           |
+|          | * ``current_password`` | ``HTTP_400_BAD_REQUEST``                  |
+|          |                        |                                           |
+|          |                        | * ``new_password``                        |
+|          |                        | * ``re_new_password``                     |
+|          |                        | * ``current_password``                    |
++----------+------------------------+-------------------------------------------+
 
 Reset Password
 --------------
@@ -171,8 +186,11 @@ setup ``PASSWORD_RESET_CONFIRM_URL``.
 +----------+---------------------------------+------------------------------+
 | Method   | Request                         | Response                     |
 +==========+=================================+==============================+
-| ``POST`` |  ``{{ User.USERNAME_FIELD }}``  | * ``HTTP_204_NO_CONTENT``    |
-|          |                                 | * ``HTTP_400_BAD_REQUEST``   |
+| ``POST`` |  ``email``                      | ``HTTP_204_NO_CONTENT``      |
+|          |                                 |                              |
+|          |                                 | ``HTTP_400_BAD_REQUEST``     |
+|          |                                 |                              |
+|          |                                 | * ``email``                  |
 +----------+---------------------------------+------------------------------+
 
 Reset Password Confirmation
@@ -182,6 +200,8 @@ Use this endpoint to finish reset password process. This endpoint is not a URL
 which will be directly exposed to your users - you should provide site in your
 frontend application (configured by ``PASSWORD_RESET_CONFIRM_URL``) which
 will send ``POST`` request to reset password confirmation endpoint.
+``HTTP_400_BAD_REQUEST`` will be raised if the user has logged in or changed password
+since the token creation.
 
 **Default URL**: ``/password/reset/confirm/``
 
@@ -192,8 +212,12 @@ will send ``POST`` request to reset password confirmation endpoint.
 +----------+----------------------------------+--------------------------------------+
 | Method   | Request                          | Response                             |
 +==========+==================================+======================================+
-| ``POST`` | * ``{{ User.USERNAME_FIELD }}``  | ``HTTP_204_NO_CONTENT``              |
+| ``POST`` | * ``uid``                        | ``HTTP_204_NO_CONTENT``              |
 |          | * ``token``                      |                                      |
-|          | * ``new_password``               |                                      |
+|          | * ``new_password``               | ``HTTP_400_BAD_REQUEST``             |
 |          | * ``re_new_password``            |                                      |
+|          |                                  | * ``uid``                            |
+|          |                                  | * ``non_field_errors``               |
+|          |                                  | * ``new_password``                   |
+|          |                                  | * ``re_new_password``                |
 +----------+----------------------------------+--------------------------------------+

--- a/docs/source/base_endpoints.rst
+++ b/docs/source/base_endpoints.rst
@@ -98,7 +98,7 @@ active when calling this endpoint (this will happen if you call it more than onc
 |          |                                      | ``HTTP_400_BAD_REQUEST``         |
 |          |                                      |                                  |
 |          |                                      | * ``uid``                        |
-|          |                                      | * ``non_field_errors``           |
+|          |                                      | * ``token``           |
 |          |                                      |                                  |
 |          |                                      | ``HTTP_403_FORBIDDEN``           |
 |          |                                      |                                  |
@@ -217,7 +217,7 @@ since the token creation.
 |          | * ``new_password``               | ``HTTP_400_BAD_REQUEST``             |
 |          | * ``re_new_password``            |                                      |
 |          |                                  | * ``uid``                            |
-|          |                                  | * ``non_field_errors``               |
+|          |                                  | * ``token``               |
 |          |                                  | * ``new_password``                   |
 |          |                                  | * ``re_new_password``                |
 +----------+----------------------------------+--------------------------------------+

--- a/testproject/testapp/tests/test_activation.py
+++ b/testproject/testapp/tests/test_activation.py
@@ -6,11 +6,10 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-import djoser.constants
 import djoser.signals
 import djoser.utils
 import djoser.views
-
+from djoser.conf import settings as default_settings
 from .common import create_user
 
 
@@ -56,7 +55,7 @@ class ActivationViewTest(restframework.APIViewTestCase,
         self.assertEqual(list(response.data.keys()), ['uid'])
         self.assertEqual(
             response.data['uid'],
-            [djoser.constants.INVALID_UID_ERROR]
+            [default_settings.CONSTANTS.messages.INVALID_UID_ERROR]
         )
 
     def test_post_respond_with_bad_request_when_stale_token(self):
@@ -74,7 +73,7 @@ class ActivationViewTest(restframework.APIViewTestCase,
         self.assertEqual(list(response.data.keys()), ['detail'])
         self.assertEqual(
             response.data['detail'],
-            djoser.constants.STALE_TOKEN_ERROR
+            default_settings.CONSTANTS.messages.STALE_TOKEN_ERROR
         )
         self.assertFalse(self.signal_sent)
 
@@ -94,7 +93,7 @@ class ActivationViewTest(restframework.APIViewTestCase,
         self.assertEqual(list(response.data.keys()), ['token'])
         self.assertEqual(
             response.data['token'],
-            [djoser.constants.INVALID_TOKEN_ERROR]
+            [default_settings.CONSTANTS.messages.INVALID_TOKEN_ERROR]
         )
 
     @override_settings(
@@ -155,7 +154,7 @@ class UserViewSetConfirmationTest(APITestCase,
         self.assertEqual(list(response.data.keys()), ['uid'])
         self.assertEqual(
             response.data['uid'],
-            [djoser.constants.INVALID_UID_ERROR]
+            [default_settings.CONSTANTS.messages.INVALID_UID_ERROR]
         )
 
     def test_post_respond_with_bad_request_when_stale_token(self):
@@ -171,7 +170,7 @@ class UserViewSetConfirmationTest(APITestCase,
         self.assertEqual(list(response.data.keys()), ['detail'])
         self.assertEqual(
             response.data['detail'],
-            djoser.constants.STALE_TOKEN_ERROR
+            default_settings.CONSTANTS.messages.STALE_TOKEN_ERROR
         )
         self.assertFalse(self.signal_sent)
 
@@ -189,7 +188,7 @@ class UserViewSetConfirmationTest(APITestCase,
         self.assertEqual(list(response.data.keys()), ['token'])
         self.assertEqual(
             response.data['token'],
-            [djoser.constants.INVALID_TOKEN_ERROR]
+            [default_settings.CONSTANTS.messages.INVALID_TOKEN_ERROR]
         )
 
     @override_settings(

--- a/testproject/testapp/tests/test_activation.py
+++ b/testproject/testapp/tests/test_activation.py
@@ -42,8 +42,10 @@ class ActivationViewTest(restframework.APIViewTestCase,
         self.assertTrue(user.is_active)
 
     def test_post_respond_with_bad_request_when_wrong_uid(self):
+        user = create_user()
         data = {
-            'uid': djoser.utils.encode_uid(1),
+            'uid': 'wrong-uid',
+            'token': default_token_generator.make_token(user),
         }
         request = self.factory.post(data=data)
 
@@ -51,6 +53,11 @@ class ActivationViewTest(restframework.APIViewTestCase,
         response.render()
 
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(list(response.data.keys()), ['uid'])
+        self.assertEqual(
+            response.data['uid'],
+            [djoser.constants.INVALID_UID_ERROR]
+        )
 
     def test_post_respond_with_bad_request_when_stale_token(self):
         user = create_user()
@@ -64,7 +71,31 @@ class ActivationViewTest(restframework.APIViewTestCase,
         response = self.view(request)
 
         self.assert_status_equal(response, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(list(response.data.keys()), ['detail'])
+        self.assertEqual(
+            response.data['detail'],
+            djoser.constants.STALE_TOKEN_ERROR
+        )
         self.assertFalse(self.signal_sent)
+
+    def test_post_respond_with_bad_request_when_wrong_token(self):
+        user = create_user()
+        djoser.signals.user_activated.connect(self.signal_receiver)
+        data = {
+            'uid': djoser.utils.encode_uid(user.pk),
+            'token': 'wrong-token',
+        }
+        request = self.factory.post(data=data)
+
+        response = self.view(request)
+        response.render()
+
+        self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(list(response.data.keys()), ['token'])
+        self.assertEqual(
+            response.data['token'],
+            [djoser.constants.INVALID_TOKEN_ERROR]
+        )
 
     @override_settings(
         DJOSER=dict(settings.DJOSER, **{'SEND_CONFIRMATION_EMAIL': True})
@@ -112,13 +143,20 @@ class UserViewSetConfirmationTest(APITestCase,
         self.assertTrue(user.is_active)
 
     def test_post_respond_with_bad_request_when_wrong_uid(self):
+        user = create_user()
         data = {
-            'uid': djoser.utils.encode_uid(0),
+            'uid': 'wrong-uid',
+            'token': default_token_generator.make_token(user),
         }
         response = self.client.post(reverse('user-confirm'), data=data)
         response.render()
 
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(list(response.data.keys()), ['uid'])
+        self.assertEqual(
+            response.data['uid'],
+            [djoser.constants.INVALID_UID_ERROR]
+        )
 
     def test_post_respond_with_bad_request_when_stale_token(self):
         user = create_user()
@@ -130,7 +168,29 @@ class UserViewSetConfirmationTest(APITestCase,
         response = self.client.post(reverse('user-confirm'), data=data)
 
         self.assert_status_equal(response, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(list(response.data.keys()), ['detail'])
+        self.assertEqual(
+            response.data['detail'],
+            djoser.constants.STALE_TOKEN_ERROR
+        )
         self.assertFalse(self.signal_sent)
+
+    def test_post_respond_with_bad_request_when_wrong_token(self):
+        user = create_user()
+        djoser.signals.user_activated.connect(self.signal_receiver)
+        data = {
+            'uid': djoser.utils.encode_uid(user.pk),
+            'token': 'wrong-token',
+        }
+        response = self.client.post(reverse('user-confirm'), data=data)
+        response.render()
+
+        self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(list(response.data.keys()), ['token'])
+        self.assertEqual(
+            response.data['token'],
+            [djoser.constants.INVALID_TOKEN_ERROR]
+        )
 
     @override_settings(
         DJOSER=dict(settings.DJOSER, **{'SEND_CONFIRMATION_EMAIL': True})

--- a/testproject/testapp/tests/test_password_reset_confirm.py
+++ b/testproject/testapp/tests/test_password_reset_confirm.py
@@ -99,7 +99,7 @@ class PasswordResetConfirmViewTest(restframework.APIViewTestCase,
 
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
-            response.data['non_field_errors'],
+            response.data['token'],
             [djoser.constants.INVALID_TOKEN_ERROR]
         )
         user.refresh_from_db()


### PR DESCRIPTION
Following up on #382, this pull request replace 'non_field_error' in password-reset-confirm and activation views with 'token' field error.