### PR TITLE
Custom email field for reset and resend views and custom user tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ This document records all notable changes to djoser.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 ---------------------
-`1.6.0`_ (2019-04-02)
+`1.6.0`_ (2019-05-15)
 ---------------------
 
 * Added Russian translation (@ozeranskiy)

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -129,16 +129,23 @@ class TokenCreateSerializer(serializers.Serializer):
 
 
 class PasswordResetSerializer(serializers.Serializer):
-    email = serializers.EmailField()
-
     default_error_messages = {'email_not_found': constants.EMAIL_NOT_FOUND}
 
-    def validate_email(self, value):
-        users = self.context['view'].get_users(value)
-        if settings.PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND and not users:
-            self.fail('email_not_found')
-        else:
-            return value
+    def __init__(self, *args, **kwargs):
+        super(PasswordResetSerializer, self).__init__(*args, **kwargs)
+
+        email_field = get_user_email_field_name(User)
+        self.fields[email_field] = serializers.EmailField()
+        validate_email_fn_name = 'validate_' + email_field
+
+        def validate_email_fn(self, value):
+            users = self.context['view'].get_users(value)
+            if settings.PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND and not users:
+                self.fail('email_not_found')
+            else:
+                return value
+
+        setattr(PasswordResetSerializer, validate_email_fn_name, validate_email_fn)
 
 
 class UidAndTokenSerializer(serializers.Serializer):

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -102,7 +102,7 @@ class ResendActivationView(ActionViewMixin, generics.GenericAPIView):
     def _action(self, serializer):
         if not settings.SEND_ACTIVATION_EMAIL:
             return response.Response(status=status.HTTP_400_BAD_REQUEST)
-        for user in self.get_users(serializer.data['email']):
+        for user in self.get_users(serializer.data[get_user_email_field_name(User)]):
             self.send_activation_email(user)
         return response.Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -181,7 +181,7 @@ class PasswordResetView(utils.ActionViewMixin, generics.GenericAPIView):
     _users = None
 
     def _action(self, serializer):
-        for user in self.get_users(serializer.data['email']):
+        for user in self.get_users(serializer.data[get_user_email_field_name(User)]):
             self.send_password_reset_email(user)
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/docs/source/base_endpoints.rst
+++ b/docs/source/base_endpoints.rst
@@ -118,7 +118,7 @@ will result in ``HTTP_400_BAD_REQUEST``
 +----------+--------------------------------------+----------------------------------+
 | Method   | Request                              | Response                         |
 +==========+======================================+==================================+
-| ``POST`` | * ``email``                          | ``HTTP_204_NO_CONTENT``          |
+| ``POST`` | * ``{{ User.EMAIL_FIELD }}``         | ``HTTP_204_NO_CONTENT``          |
 |          |                                      | ``HTTP_400_BAD_REQUEST``         |
 +----------+--------------------------------------+----------------------------------+
 
@@ -181,16 +181,16 @@ setup ``PASSWORD_RESET_CONFIRM_URL``.
 
     ``HTTP_204_NO_CONTENT`` if ``PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND`` is ``False``
 
-    Otherwise and if ``email`` does not exist in database ``HTTP_400_BAD_REQUEST``
+    Otherwise and if ``{{ User.EMAIL_FIELD }}`` does not exist in database ``HTTP_400_BAD_REQUEST``
 
 +----------+---------------------------------+------------------------------+
 | Method   | Request                         | Response                     |
 +==========+=================================+==============================+
-| ``POST`` |  ``email``                      | ``HTTP_204_NO_CONTENT``      |
+| ``POST`` |  ``{{ User.EMAIL_FIELD }}``     | ``HTTP_204_NO_CONTENT``      |
 |          |                                 |                              |
 |          |                                 | ``HTTP_400_BAD_REQUEST``     |
 |          |                                 |                              |
-|          |                                 | * ``email``                  |
+|          |                                 | * ``{{ User.EMAIL_FIELD }}`` |
 +----------+---------------------------------+------------------------------+
 
 Reset Password Confirmation

--- a/docs/source/base_endpoints.rst
+++ b/docs/source/base_endpoints.rst
@@ -23,6 +23,10 @@ Use this endpoint to retrieve/update user.
 |          |                                | * ``{{ User.USERNAME_FIELD }}``  |
 |          |                                | * ``{{ User._meta.pk.name }}``   |
 |          |                                | * ``{{ User.REQUIRED_FIELDS }}`` |
+|          |                                |                                  |
+|          |                                | ``HTTP_400_BAD_REQUEST``         |
+|          |                                |                                  |
+|          |                                | * ``{{ User.REQUIRED_FIELDS }}`` |
 +----------+--------------------------------+----------------------------------+
 
 User Create
@@ -45,6 +49,12 @@ fields.
 |          | * ``password``                    | * ``{{ User.USERNAME_FIELD }}``  |
 |          |                                   | * ``{{ User._meta.pk.name }}``   |
 |          |                                   | * ``{{ User.REQUIRED_FIELDS }}`` |
+|          |                                   |                                  |
+|          |                                   | ``HTTP_400_BAD_REQUEST``         |
+|          |                                   |                                  |
+|          |                                   | * ``{{ User.USERNAME_FIELD }}``  |
+|          |                                   | * ``{{ User.REQUIRED_FIELDS }}`` |
+|          |                                   | * ``password``                   |
 +----------+-----------------------------------+----------------------------------+
 
 User Delete
@@ -56,6 +66,7 @@ based authentication is used and invoke delete for a given ``User`` instance.
 One of ways to customize the delete behavior is to override ``User.delete``.
 
 **Default URL**: ``/users/me/``
+**Backward-compatible URL**: ``/users/delete/``
 
 +------------+---------------------------------+----------------------------------+
 | Method     |  Request                        | Response                         |
@@ -67,26 +78,14 @@ One of ways to customize the delete behavior is to override ``User.delete``.
 |            |                                 | * ``current_password``           |
 +------------+---------------------------------+----------------------------------+
 
-**Backward-compatible URL**: ``/users/delete/``
-
-+----------+-----------------------------------+----------------------------------+
-| Method   |  Request                          | Response                         |
-+==========+===================================+==================================+
-| ``POST`` | * ``current_password``            | ``HTTP_204_NO_CONTENT``          |
-|          |                                   |                                  |
-|          |                                   | ``HTTP_400_BAD_REQUEST``         |
-|          |                                   |                                  |
-|          |                                   | * ``current_password``           |
-+----------+-----------------------------------+----------------------------------+
-
-
 User Activate
 -------------
 
 Use this endpoint to activate user account. This endpoint is not a URL which
 will be directly exposed to your users - you should provide site in your
 frontend application (configured by ``ACTIVATION_URL``) which will send ``POST``
-request to activate endpoint.
+request to activate endpoint. ``HTTP_403_FORBIDDEN`` will be raised if user is already
+active when calling this endpoint (this will happen if you call it more than once).
 
 **Default URL**: ``/users/confirm/``
 **Backward-compatible URL**: ``/users/activate/``
@@ -94,8 +93,16 @@ request to activate endpoint.
 +----------+--------------------------------------+----------------------------------+
 | Method   | Request                              | Response                         |
 +==========+======================================+==================================+
-| ``POST`` | * ``{{ User.USERNAME_FIELD }}``      | ``HTTP_204_NO_CONTENT``          |
+| ``POST`` | * ``uid``                            | ``HTTP_204_NO_CONTENT``          |
 |          | * ``token``                          |                                  |
+|          |                                      | ``HTTP_400_BAD_REQUEST``         |
+|          |                                      |                                  |
+|          |                                      | * ``uid``                        |
+|          |                                      | * ``non_field_errors``           |
+|          |                                      |                                  |
+|          |                                      | ``HTTP_403_FORBIDDEN``           |
+|          |                                      |                                  |
+|          |                                      | * ``detail``                     |
 +----------+--------------------------------------+----------------------------------+
 
 User Resend Activation E-mail
@@ -111,7 +118,7 @@ will result in ``HTTP_400_BAD_REQUEST``
 +----------+--------------------------------------+----------------------------------+
 | Method   | Request                              | Response                         |
 +==========+======================================+==================================+
-| ``POST`` | * ``{{ User.USERNAME_FIELD }}``      | ``HTTP_204_NO_CONTENT``          |
+| ``POST`` | * ``email``                          | ``HTTP_204_NO_CONTENT``          |
 |          |                                      | ``HTTP_400_BAD_REQUEST``         |
 +----------+--------------------------------------+----------------------------------+
 
@@ -127,13 +134,17 @@ Use this endpoint to change user username (``USERNAME_FIELD``).
 
     ``re_new_{{ User.USERNAME_FIELD }}`` is only required if ``SET_USERNAME_RETYPE`` is ``True``
 
-+----------+----------------------------------------+--------------------------------------+
-| Method   | Request                                | Response                             |
-+==========+========================================+======================================+
-| ``POST`` | * ``new_{{ User.USERNAME_FIELD }}``    | ``HTTP_204_NO_CONTENT``              |
-|          | * ``re_new_{{ User.USERNAME_FIELD }}`` |                                      |
-|          | * ``current_password``                 |                                      |
-+----------+----------------------------------------+--------------------------------------+
++----------+----------------------------------------+-------------------------------------------+
+| Method   | Request                                | Response                                  |
++==========+========================================+===========================================+
+| ``POST`` | * ``new_{{ User.USERNAME_FIELD }}``    | ``HTTP_204_NO_CONTENT``                   |
+|          | * ``re_new_{{ User.USERNAME_FIELD }}`` |                                           |
+|          | * ``current_password``                 | ``HTTP_400_BAD_REQUEST``                  |
+|          |                                        |                                           |
+|          |                                        | * ``new_{{ User.USERNAME_FIELD }}``       |
+|          |                                        | * ``re_new_{{ User.USERNAME_FIELD }}``    |
+|          |                                        | * ``current_password``                    |
++----------+----------------------------------------+-------------------------------------------+
 
 Set Password
 ------------
@@ -146,13 +157,17 @@ Use this endpoint to change user password.
 
     ``re_new_password`` is only required if ``SET_PASSWORD_RETYPE`` is ``True``
 
-+----------+------------------------+--------------------------------------+
-| Method   | Request                | Response                             |
-+==========+========================+======================================+
-| ``POST`` | * ``new_password``     | ``HTTP_204_NO_CONTENT``              |
-|          | * ``re_new_password``  |                                      |
-|          | * ``current_password`` |                                      |
-+----------+------------------------+--------------------------------------+
++----------+------------------------+-------------------------------------------+
+| Method   | Request                | Response                                  |
++==========+========================+===========================================+
+| ``POST`` | * ``new_password``     | ``HTTP_204_NO_CONTENT``                   |
+|          | * ``re_new_password``  |                                           |
+|          | * ``current_password`` | ``HTTP_400_BAD_REQUEST``                  |
+|          |                        |                                           |
+|          |                        | * ``new_password``                        |
+|          |                        | * ``re_new_password``                     |
+|          |                        | * ``current_password``                    |
++----------+------------------------+-------------------------------------------+
 
 Reset Password
 --------------
@@ -171,8 +186,11 @@ setup ``PASSWORD_RESET_CONFIRM_URL``.
 +----------+---------------------------------+------------------------------+
 | Method   | Request                         | Response                     |
 +==========+=================================+==============================+
-| ``POST`` |  ``{{ User.USERNAME_FIELD }}``  | * ``HTTP_204_NO_CONTENT``    |
-|          |                                 | * ``HTTP_400_BAD_REQUEST``   |
+| ``POST`` |  ``email``                      | ``HTTP_204_NO_CONTENT``      |
+|          |                                 |                              |
+|          |                                 | ``HTTP_400_BAD_REQUEST``     |
+|          |                                 |                              |
+|          |                                 | * ``email``                  |
 +----------+---------------------------------+------------------------------+
 
 Reset Password Confirmation
@@ -182,6 +200,8 @@ Use this endpoint to finish reset password process. This endpoint is not a URL
 which will be directly exposed to your users - you should provide site in your
 frontend application (configured by ``PASSWORD_RESET_CONFIRM_URL``) which
 will send ``POST`` request to reset password confirmation endpoint.
+``HTTP_400_BAD_REQUEST`` will be raised if the user has logged in or changed password
+since the token creation.
 
 **Default URL**: ``/password/reset/confirm/``
 
@@ -192,8 +212,12 @@ will send ``POST`` request to reset password confirmation endpoint.
 +----------+----------------------------------+--------------------------------------+
 | Method   | Request                          | Response                             |
 +==========+==================================+======================================+
-| ``POST`` | * ``{{ User.USERNAME_FIELD }}``  | ``HTTP_204_NO_CONTENT``              |
+| ``POST`` | * ``uid``                        | ``HTTP_204_NO_CONTENT``              |
 |          | * ``token``                      |                                      |
-|          | * ``new_password``               |                                      |
+|          | * ``new_password``               | ``HTTP_400_BAD_REQUEST``             |
 |          | * ``re_new_password``            |                                      |
+|          |                                  | * ``uid``                            |
+|          |                                  | * ``non_field_errors``               |
+|          |                                  | * ``new_password``                   |
+|          |                                  | * ``re_new_password``                |
 +----------+----------------------------------+--------------------------------------+

--- a/testproject/testapp/models.py
+++ b/testproject/testapp/models.py
@@ -1,0 +1,30 @@
+from django.contrib.auth.base_user import BaseUserManager
+from django.contrib.auth.models import AbstractBaseUser
+from django.db import models
+
+
+class CustomUserManager(BaseUserManager):
+    use_in_migrations = True
+
+    def create_user(self, custom_username, custom_email=None, password=None, **extra_fields):
+        if not custom_username:
+            raise ValueError('The given custom_username must be set')
+        email = self.normalize_email(custom_email)
+        username = self.model.normalize_username(custom_username)
+        user = self.model(custom_username=username, custom_email=email, **extra_fields)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+
+class CustomUser(AbstractBaseUser):
+    custom_username = models.CharField(max_length=150)
+    custom_email = models.EmailField(blank=True)
+    custom_required_field = models.CharField(max_length=2)
+    is_active = models.BooleanField(default=True)
+    objects = CustomUserManager()
+
+    EMAIL_FIELD = 'custom_email'
+    USERNAME_FIELD = 'custom_username'
+    REQUIRED_FIELDS = ['custom_email', 'custom_required_field']
+

--- a/testproject/testapp/tests/common.py
+++ b/testproject/testapp/tests/common.py
@@ -9,11 +9,16 @@ except ImportError:
 __all__ = ['get_user_model', 'IntegrityError', 'mock']
 
 
-def create_user(**kwargs):
+def create_user(use_custom_data=False, **kwargs):
     data = {
         'username': 'john',
         'password': 'secret',
         'email': 'john@beatles.com',
+    } if not use_custom_data else {
+        'custom_username': 'john',
+        'password': 'secret',
+        'custom_email': 'john@beatles.com',
+        'custom_required_field': '42',
     }
     data.update(kwargs)
     user = get_user_model().objects.create_user(**data)

--- a/testproject/testapp/tests/test_activation.py
+++ b/testproject/testapp/tests/test_activation.py
@@ -6,7 +6,6 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-import djoser.constants
 import djoser.signals
 import djoser.utils
 import djoser.views

--- a/testproject/testapp/tests/test_password_reset.py
+++ b/testproject/testapp/tests/test_password_reset.py
@@ -9,7 +9,7 @@ import djoser.views
 from djoser.compat import get_user_email
 from djoser.conf import settings as default_settings
 from .common import create_user, mock
-from ..models import CustomUser
+from testapp.models import CustomUser
 
 
 class PasswordResetViewTest(restframework.APIViewTestCase,

--- a/testproject/testapp/tests/test_password_reset.py
+++ b/testproject/testapp/tests/test_password_reset.py
@@ -8,8 +8,10 @@ from rest_framework import status
 
 import djoser.constants
 import djoser.views
+from djoser.compat import get_user_email
 
-from .common import create_user
+from .common import create_user, mock
+from ..models import CustomUser
 
 
 class PasswordResetViewTest(restframework.APIViewTestCase,
@@ -79,4 +81,47 @@ class PasswordResetViewTest(restframework.APIViewTestCase,
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.data['email'][0], djoser.constants.EMAIL_NOT_FOUND
+        )
+
+    @mock.patch(
+        'djoser.serializers.User', CustomUser)
+    @mock.patch(
+        'djoser.views.User', CustomUser)
+    @override_settings(
+        AUTH_USER_MODEL='testapp.CustomUser')
+    def test_post_should_send_email_to_custom_user_with_password_reset_link(self):
+        user = create_user(use_custom_data=True)
+        data = {
+            'custom_email': get_user_email(user),
+        }
+        request = self.factory.post(data=data)
+
+        response = self.view(request)
+
+        self.assert_status_equal(response, status.HTTP_204_NO_CONTENT)
+        self.assert_emails_in_mailbox(1)
+        self.assert_email_exists(to=[get_user_email(user)])
+        site = get_current_site(request)
+        self.assertIn(site.domain, mail.outbox[0].body)
+        self.assertIn(site.name, mail.outbox[0].body)
+
+    @mock.patch(
+        'djoser.serializers.User', CustomUser)
+    @mock.patch(
+        'djoser.views.User', CustomUser)
+    @override_settings(
+        AUTH_USER_MODEL='testapp.CustomUser',
+        DJOSER=dict(settings.DJOSER,
+                    **{'PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND': True}))
+    def test_post_should_return_bad_request_with_custom_email_field_if_user_does_not_exist(self):
+        data = {
+            'custom_email': 'john@beatles.com',
+        }
+        request = self.factory.post(data=data)
+
+        response = self.view(request)
+
+        self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data['custom_email'][0], djoser.constants.EMAIL_NOT_FOUND
         )

--- a/testproject/testapp/tests/test_password_reset_confirm.py
+++ b/testproject/testapp/tests/test_password_reset_confirm.py
@@ -4,7 +4,6 @@ from django.test.utils import override_settings
 from djet import assertions, restframework
 from rest_framework import status
 
-import djoser.constants
 import djoser.utils
 import djoser.views
 from djoser.conf import settings as default_settings

--- a/testproject/testapp/tests/test_set_username.py
+++ b/testproject/testapp/tests/test_set_username.py
@@ -9,7 +9,7 @@ from rest_framework.test import APITestCase
 import djoser.views
 
 from .common import create_user, mock
-from ..models import CustomUser
+from testapp.models import CustomUser
 
 
 class SetUsernameViewTest(restframework.APIViewTestCase,

--- a/testproject/testapp/tests/test_user_create.py
+++ b/testproject/testapp/tests/test_user_create.py
@@ -11,7 +11,7 @@ from rest_framework.test import APITestCase
 import djoser.views
 from djoser.conf import settings as default_settings
 from djoser.compat import get_user_email
-from ..models import CustomUser
+from testapp.models import CustomUser
 from .common import create_user, mock, perform_create_mock
 
 User = get_user_model()


### PR DESCRIPTION
Following up on #382, this pull request replace 'email' in password-reset and activation-resend views with 'EMAIL_FIELD' field.

I also added some tests that checks djoser compatibility with custom user model by testing different endpoints with custom username, email and required fields.
I needed to use a lot of mock so the test cases aren't pretty, but changing the user model dynamically when the app has already loaded causes some conflicts and I didn't find a better solution. 

If this and #383 are both accepted, I'll handle the merge conflict between those two depending on the first one that get merged.
