### PR TITLE
added USER_CREATE_PASSWORD_RETYPE option

### DIFF
--- a/djoser/conf.py
+++ b/djoser/conf.py
@@ -28,6 +28,7 @@ class ObjDict(dict):
 default_settings = {
     'SEND_ACTIVATION_EMAIL': False,
     'SEND_CONFIRMATION_EMAIL': False,
+    'USER_CREATE_PASSWORD_RETYPE': False,
     'SET_PASSWORD_RETYPE': False,
     'SET_USERNAME_RETYPE': False,
     'PASSWORD_RESET_CONFIRM_RETYPE': False,
@@ -53,6 +54,8 @@ default_settings = {
             'djoser.serializers.SetUsernameRetypeSerializer',
         'user_create':
             'djoser.serializers.UserCreateSerializer',
+        'user_create_password_retype':
+            'djoser.serializers.UserCreatePasswordRetypeSerializer',
         'user_delete':
             'djoser.serializers.UserDeleteSerializer',
         'user':

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -96,6 +96,24 @@ class UserCreateSerializer(serializers.ModelSerializer):
         return user
 
 
+class UserCreatePasswordRetypeSerializer(UserCreateSerializer):
+    default_error_messages = {
+        'password_mismatch': settings.CONSTANTS.messages.PASSWORD_MISMATCH_ERROR,
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(UserCreatePasswordRetypeSerializer, self).__init__(*args, **kwargs)
+        self.fields['re_password'] = serializers.CharField(style={'input_type': 'password'})
+
+    def validate(self, attrs):
+        re_password = attrs.pop('re_password')
+        attrs = super(UserCreatePasswordRetypeSerializer, self).validate(attrs)
+        if attrs['password'] == re_password:
+            return attrs
+        else:
+            self.fail('password_mismatch')
+
+
 class TokenCreateSerializer(serializers.Serializer):
     password = serializers.CharField(
         required=False, style={'input_type': 'password'}

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -86,8 +86,12 @@ class UserCreateView(UserCreateMixin, generics.CreateAPIView):
     """
     Use this endpoint to register new user.
     """
-    serializer_class = settings.SERIALIZERS.user_create
     permission_classes = settings.PERMISSIONS.user_create
+
+    def get_serializer_class(self):
+        if settings.USER_CREATE_PASSWORD_RETYPE:
+            return settings.SERIALIZERS.user_create_password_retype
+        return settings.SERIALIZERS.user_create
 
 
 class ResendActivationView(ActionViewMixin, generics.GenericAPIView):
@@ -343,6 +347,8 @@ class UserViewSet(UserCreateMixin,
 
     def get_serializer_class(self):
         if self.action == 'create':
+            if settings.USER_CREATE_PASSWORD_RETYPE:
+                return settings.SERIALIZERS.user_create_password_retype
             return settings.SERIALIZERS.user_create
 
         elif self.action == 'remove' or (

--- a/docs/source/base_endpoints.rst
+++ b/docs/source/base_endpoints.rst
@@ -41,13 +41,17 @@ fields.
 **Default URL**: ``/users/``
 **Backward-compatible URL**: ``/users/create/``
 
+.. note::
+
+    ``re_password`` is only required if ``USER_CREATE_PASSWORD_RETYPE`` is ``True``
+
 +----------+-----------------------------------+----------------------------------+
 | Method   |  Request                          | Response                         |
 +==========+===================================+==================================+
 | ``POST`` | * ``{{ User.USERNAME_FIELD }}``   | ``HTTP_201_CREATED``             |
 |          | * ``{{ User.REQUIRED_FIELDS }}``  |                                  |
 |          | * ``password``                    | * ``{{ User.USERNAME_FIELD }}``  |
-|          |                                   | * ``{{ User._meta.pk.name }}``   |
+|          | * ``re_password``                 | * ``{{ User._meta.pk.name }}``   |
 |          |                                   | * ``{{ User.REQUIRED_FIELDS }}`` |
 |          |                                   |                                  |
 |          |                                   | ``HTTP_400_BAD_REQUEST``         |
@@ -55,6 +59,7 @@ fields.
 |          |                                   | * ``{{ User.USERNAME_FIELD }}``  |
 |          |                                   | * ``{{ User.REQUIRED_FIELDS }}`` |
 |          |                                   | * ``password``                   |
+|          |                                   | * ``re_password``                |
 +----------+-----------------------------------+----------------------------------+
 
 User Delete

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -49,6 +49,14 @@ placeholders, e.g. ``#/activate/{uid}/{token}``. You should pass ``uid`` and
 
 **Required**: ``True``
 
+USER_CREATE_PASSWORD_RETYPE
+---------------------------
+
+If ``True``, you need to pass ``re_password`` to
+``/users/`` endpoint, to validate password equality.
+
+**Default**: ``False``
+
 SET_USERNAME_RETYPE
 -------------------
 

--- a/testproject/testapp/tests/test_user_create.py
+++ b/testproject/testapp/tests/test_user_create.py
@@ -114,6 +114,27 @@ class UserCreateViewTest(restframework.APIViewTestCase,
                 'no666',
             )
 
+    @override_settings(
+        DJOSER=dict(settings.DJOSER, **{'USER_CREATE_PASSWORD_RETYPE': True})
+    )
+    def test_post_not_register_if_password_mismatch(self):
+        data = {
+            'username': 'john',
+            'password': 'secret',
+            're_password': 'wrong',
+            'csrftoken': 'asdf',
+        }
+
+        request = self.factory.post(data=data)
+        response = self.view(request)
+
+        self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
+        response.render()
+        self.assertEqual(
+            str(response.data['non_field_errors'][0]),
+            default_settings.CONSTANTS.messages.PASSWORD_MISMATCH_ERROR,
+        )
+
     @mock.patch(
         'djoser.serializers.UserCreateSerializer.perform_create',
         side_effect=perform_create_mock
@@ -225,6 +246,25 @@ class UserViewSetCreationTest(APITestCase,
                 response.data['password'][0].code,
                 'no666',
             )
+
+    @override_settings(
+        DJOSER=dict(settings.DJOSER, **{'USER_CREATE_PASSWORD_RETYPE': True})
+    )
+    def test_post_not_register_if_password_mismatch(self):
+        data = {
+            'username': 'john',
+            'password': 'secret',
+            're_password': 'wrong',
+            'csrftoken': 'asdf',
+        }
+
+        response = self.client.post(reverse('user-list'), data=data)
+
+        self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            str(response.data['non_field_errors'][0]),
+            default_settings.CONSTANTS.messages.PASSWORD_MISMATCH_ERROR,
+        )
 
     @mock.patch(
         'djoser.serializers.UserCreateSerializer.perform_create',


### PR DESCRIPTION
I think that the user creation endpoint is missing a password confirmation option. Lots of websites ask twice for the password on registration