### PR TITLE
ka locale fixed missing site_name

### DIFF
--- a/djoser/locale/ka/LC_MESSAGES/django.po
+++ b/djoser/locale/ka/LC_MESSAGES/django.po
@@ -99,7 +99,7 @@ msgstr "საიტის %(site_name)s გუნდი"
 #, python-format
 msgid ""
 "%(site_name)s - Your account has been successfully created and activated!"
-msgstr "თქვენი ანგარიში წარმატებით შეიქმნილია და გააკტიურებულია."
+msgstr "%(site_name)s - თქვენი ანგარიში წარმატებით შეიქმნილია და გააკტიურებულია."
 
 #: templates/email/confirmation.html:8 templates/email/confirmation.html:16
 msgid "Your account has been created and is ready to use!"


### PR DESCRIPTION
The compilation of the Georgian translation raised an error of a missing argument « site_name » format. I fixed it, but since I don't speak Georgian, @zefciu could you confirm that the translation is still correct?