### PR TITLE
Minor update to settings docs

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -99,7 +99,7 @@ If ``True``, setting new password will logout the user.
 
 .. note::
 
-    Logout will only works with token based authentication.
+    Logout only works with token based authentication.
 
 USER_EMAIL_FIELD_NAME
 ---------------------

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -70,7 +70,7 @@ SET_USERNAME_RETYPE
 -------------------
 
 If ``True``, you need to pass ``re_new_{{ User.USERNAME_FIELD }}`` to
-``/{{ User.USERNAME_FIELD }}/`` endpoint, to validate username equality.
+``/users/change_username/`` endpoint, to validate username equality.
 
 **Default**: ``False``
 
@@ -96,6 +96,10 @@ LOGOUT_ON_PASSWORD_CHANGE
 If ``True``, setting new password will logout the user.
 
 **Default**: ``False``
+
+.. note::
+
+    Logout will only works with token based authentication.
 
 USER_EMAIL_FIELD_NAME
 ---------------------


### PR DESCRIPTION
I noticed there was one endpoint that was still using the backward compatible url and the setting LOGOUT_ON_PASSWORD_CHANGE doesn't have any effect when you use JWT so I added a note about it.