### PR TITLE
New functionality, when password was changed, send email with confirm…

### DIFF
--- a/djoser/conf.py
+++ b/djoser/conf.py
@@ -39,6 +39,7 @@ default_settings = {
     'SET_USERNAME_RETYPE': False,
     'PASSWORD_RESET_CONFIRM_RETYPE': False,
     'PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND': False,
+    'PASSWORD_CHANGED_EMAIL_CONFIRMATION': False,
     'PASSWORD_VALIDATORS': [],
     'TOKEN_MODEL': 'rest_framework.authtoken.models.Token',
     'SERIALIZERS': ObjDict({
@@ -77,6 +78,8 @@ default_settings = {
         'activation': 'djoser.email.ActivationEmail',
         'confirmation': 'djoser.email.ConfirmationEmail',
         'password_reset': 'djoser.email.PasswordResetEmail',
+        'password_changed_confirmation':
+            'djoser.email.PasswordChangedConfirmationEmail',
     }),
     'CONSTANTS': ObjDict({
         'messages': 'djoser.constants.Messages',

--- a/djoser/email.py
+++ b/djoser/email.py
@@ -34,3 +34,7 @@ class PasswordResetEmail(BaseEmailMessage):
         context['token'] = default_token_generator.make_token(user)
         context['url'] = settings.PASSWORD_RESET_CONFIRM_URL.format(**context)
         return context
+
+
+class PasswordChangedConfirmationEmail(BaseEmailMessage):
+    template_name = 'email/password_changed_confirmation.html'

--- a/djoser/templates/email/password_changed_confirmation.html
+++ b/djoser/templates/email/password_changed_confirmation.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+
+{% block subject %}
+{% blocktrans %}{{ site_name }} - Your password has been successfully changed!{% endblocktrans %}
+{% endblock %}
+
+{% block text_body %}
+{% trans "Your password has been changed!" %}
+
+{% trans "Thanks for using our site!" %}
+
+{% blocktrans %}The {{ site_name }} team{% endblocktrans %}
+{% endblock text_body %}
+
+{% block html_body %}
+<p>{% trans "Your password has been changed!" %}</p>
+
+<p>{% trans "Thanks for using our site!" %}</p>
+
+<p>{% blocktrans %}The {{ site_name }} team{% endblocktrans %}</p>
+{% endblock html_body %}

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -49,6 +49,13 @@ If ``True``, register or activation endpoint will send confirmation email to use
 
 **Default**: ``False``
 
+PASSWORD_CHANGED_EMAIL_CONFIRMATION
+-----------------------
+
+If ``True``, change password endpoints will send confirmation email to user.
+
+**Default**: ``False``
+
 ACTIVATION_URL
 --------------
 


### PR DESCRIPTION
When password has been change it's nice to notify our user about this.
I was considering if `PASSWORD_CHANGE _EMAIL CONFIRMATION` should also be applied to `set_password` endpoint.