### PR TITLE
Convenient configure of passwords strength

### DIFF
--- a/djoser/conf.py
+++ b/djoser/conf.py
@@ -40,6 +40,7 @@ default_settings = {
     'PASSWORD_RESET_CONFIRM_RETYPE': False,
     'PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND': False,
     'PASSWORD_VALIDATORS': [],
+    'ALLOW_ANY_PASSWORD': False,
     'TOKEN_MODEL': 'rest_framework.authtoken.models.Token',
     'SERIALIZERS': ObjDict({
         'activation':

--- a/testproject/testapp/validators.py
+++ b/testproject/testapp/validators.py
@@ -5,3 +5,9 @@ class Is666(object):
     def validate(self, password, *args, **kwargs):
         if password == '666':
             raise ValidationError("Password 666 is not allowed.", code='no666')
+
+
+class Is666666(object):
+    def validate(self, password, *args, **kwargs):
+        if password == '666666':
+            raise ValidationError("Password 666666 is extremely not allowed.", code='no666666')


### PR DESCRIPTION
1. Added the optional setting ALLOW_ANY_PASSWORD.
It disables all password validators and allows to set any password.
False by default.

2. If there is password validators according to [django validators settings format](https://docs.djangoproject.com/en/2.2/topics/auth/passwords/#enabling-password-validation) in PASSWORD_VALIDATORS option, they overrides default validators from a project settings AUTH_PASSWORD_VALIDATORS list.