### PR TITLE
DRF 3.10 support

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -65,10 +65,10 @@
         },
         "djangorestframework": {
             "hashes": [
-                "sha256:376f4b50340a46c15ae15ddd0c853085f4e66058f97e4dbe7d43ed62f5e60651",
-                "sha256:c12869cfd83c33d579b17b3cb28a2ae7322a53c3ce85580c2a2ebe4e3f56c4fb"
+                "sha256:1f274ebbb930dfa709751fac31b2332b2e662303f8c66d7eacea534702611e34",
+                "sha256:bd389598d052fb79a68904eff35d34303118b5c2abefa65329b5f1a07b571ce1"
             ],
-            "version": "==3.9.4"
+            "version": "==3.10.0"
         },
         "djangorestframework-simplejwt": {
             "hashes": [

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ To be able to run **djoser** you have to meet following requirements:
 
 - Python (2.7, 3.4, 3.5, 3.6)
 - Django (1.11, 2.0, 2.1, 2.2)
-- Django REST Framework (3.7, 3.8, 3.9)
+- Django REST Framework (3.8, 3.9, 3.10)
 
 Bear in mind that for Django-2.x you will need at least Python 3.5
 

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -3,7 +3,7 @@ from django.contrib.auth.tokens import default_token_generator
 from django.urls.exceptions import NoReverseMatch
 from django.utils.timezone import now
 from rest_framework import generics, permissions, response, status, views, viewsets
-from rest_framework.decorators import list_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
@@ -388,7 +388,7 @@ class UserViewSet(UserCreateMixin, UserUpdateMixin, viewsets.ModelViewSet):
         self.perform_destroy(instance)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    @list_route(["get", "put", "patch", "delete"])
+    @action(methods=["get", "put", "patch", "delete"], detail=False)
     def me(self, request, *args, **kwargs):
         self.get_object = self.get_instance
         if request.method == "GET":
@@ -400,7 +400,7 @@ class UserViewSet(UserCreateMixin, UserUpdateMixin, viewsets.ModelViewSet):
         elif request.method == "DELETE":
             return self.destroy(request, *args, **kwargs)
 
-    @list_route(["post"])
+    @action(methods=["post"], detail=False)
     def confirm(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -419,7 +419,7 @@ class UserViewSet(UserCreateMixin, UserUpdateMixin, viewsets.ModelViewSet):
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    @list_route(["post"])
+    @action(methods=["post"], detail=False)
     def change_username(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/testproject/settings.py
+++ b/testproject/settings.py
@@ -43,6 +43,7 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.TokenAuthentication",
     ),
     "NON_FIELD_ERRORS_KEY": "yolo",
+    "DEFAULT_SCHEMA_CLASS": "rest_framework.schemas.coreapi.AutoSchema",
 }
 
 ROOT_URLCONF = "urls"

--- a/testproject/settings.py
+++ b/testproject/settings.py
@@ -43,7 +43,6 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.TokenAuthentication",
     ),
     "NON_FIELD_ERRORS_KEY": "yolo",
-    "DEFAULT_SCHEMA_CLASS": "rest_framework.schemas.coreapi.AutoSchema",
 }
 
 ROOT_URLCONF = "urls"

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{27,34,35,36}-django111-drf{37,38,39}
-    py{35,36,37}-django20-drf{37,38,39}
-    py{35,36,37}-django21-drf{38,39}
-    py{35,36,37}-django22-drf{38,39}
+    py{27,34,35,36}-django111-drf{38,39}
+    py{35,36,37}-django20-drf{38,39,310}
+    py{35,36,37}-django21-drf{38,39,310}
+    py{35,36,37}-django22-drf{38,39,310}
     flake8
 
 [testenv]
@@ -22,6 +22,7 @@ deps =
     drf37: djangorestframework>=3.7,<3.8
     drf38: djangorestframework>=3.8,<3.9
     drf39: djangorestframework>=3.9,<3.10
+    drf310: djangorestframework>=3.10,<3.11
     py27: mock
     -rrequirements.txt
 commands =


### PR DESCRIPTION
Django Rest Framework 3.10.0 was released this morning, and removed the @list_route decorator ([deprecated](https://www.django-rest-framework.org/community/3.8-announcement/#action-decorator-replaces-list_route-and-detail_route) since DRF 3.8). This PR updates those decorators.

It also fixes `test_drf_docs()`, which breaks with DRF 3.10. To do this, I added a default schema class in the example project per the [release notes](https://www.django-rest-framework.org/community/3.10-announcement/#continuing-to-use-coreapi). I'd love a second set of eyes on if this is the correct way to fix this issue (at least during the deprecation window), since I haven't worked with CoreAPI vs OpenAPI schemas in DRF before

- moving from @list_route to @action decorator
- adding a default schema class to the example project
  (https://www.django-rest-framework.org/community/3.10-announcement/#continuing-to-use-coreapi)