### PR TITLE
Send the confirmation email after user activation

### DIFF
--- a/djoser/views.py
+++ b/djoser/views.py
@@ -185,7 +185,7 @@ class UserViewSet(viewsets.ModelViewSet):
         if settings.SEND_CONFIRMATION_EMAIL:
             context = {"user": user}
             to = [get_user_email(user)]
-            settings.EMAIL.activation(self.request, context).send(to)
+            settings.EMAIL.confirmation(self.request, context).send(to)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
We recently upgraded to the latest djoser version, and our test suite caught an issue with sending out confirmation emails after a user has been successfully activated. It turns out, the wrong email is sent in djoser's activate view.