### PR TITLE
ID_FIELD setting added

### DIFF
--- a/djoser/conf.py
+++ b/djoser/conf.py
@@ -27,6 +27,7 @@ class ObjDict(dict):
 
 
 default_settings = {
+    "ID_FIELD": User._meta.pk.name,
     "LOGIN_FIELD": User.USERNAME_FIELD,
     "SEND_ACTIVATION_EMAIL": False,
     "SEND_CONFIRMATION_EMAIL": False,

--- a/djoser/conf.py
+++ b/djoser/conf.py
@@ -27,7 +27,7 @@ class ObjDict(dict):
 
 
 default_settings = {
-    "ID_FIELD": User._meta.pk.name,
+    "USER_ID_FIELD": User._meta.pk.name,
     "LOGIN_FIELD": User.USERNAME_FIELD,
     "SEND_ACTIVATION_EMAIL": False,
     "SEND_CONFIRMATION_EMAIL": False,

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -16,7 +16,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = tuple(User.REQUIRED_FIELDS) + (
-            settings.ID_FIELD,
+            settings.USER_ID_FIELD,
             settings.LOGIN_FIELD,
         )
         read_only_fields = (settings.LOGIN_FIELD,)
@@ -42,7 +42,7 @@ class UserCreateSerializer(serializers.ModelSerializer):
         model = User
         fields = tuple(User.REQUIRED_FIELDS) + (
             settings.LOGIN_FIELD,
-            settings.ID_FIELD,
+            settings.USER_ID_FIELD,
             "password",
         )
 

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -16,7 +16,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = tuple(User.REQUIRED_FIELDS) + (
-            User._meta.pk.name,
+            settings.ID_FIELD,
             settings.LOGIN_FIELD,
         )
         read_only_fields = (settings.LOGIN_FIELD,)
@@ -42,7 +42,7 @@ class UserCreateSerializer(serializers.ModelSerializer):
         model = User
         fields = tuple(User.REQUIRED_FIELDS) + (
             settings.LOGIN_FIELD,
-            User._meta.pk.name,
+            settings.ID_FIELD,
             "password",
         )
 

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -46,6 +46,7 @@ class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     permission_classes = settings.PERMISSIONS.user
     token_generator = default_token_generator
+    lookup_field = settings.ID_FIELD
 
     def permission_denied(self, request, message=None):
         if (

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -46,7 +46,7 @@ class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     permission_classes = settings.PERMISSIONS.user
     token_generator = default_token_generator
-    lookup_field = settings.ID_FIELD
+    lookup_field = settings.USER_ID_FIELD
 
     def permission_denied(self, request, message=None):
         if (

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -17,6 +17,13 @@ You can provide ``DJOSER`` settings like this:
 
     All following setting names written in CAPS are keys on ``DJOSER`` dict.
 
+USER_ID_FIELD
+-------------
+
+Name of a unique field in User model to be used as id for ``/users/<id>/`` endpoints.
+This is useful if you want to not change default primary key of the User model and hide from public.
+
+**Default**: ``User._meta.pk.name`` where ``User`` is the model set with Django's setting AUTH_USER_MODEL.
 
 LOGIN_FIELD
 -----------

--- a/testproject/testapp/tests/test_user_delete.py
+++ b/testproject/testapp/tests/test_user_delete.py
@@ -94,7 +94,7 @@ class UserViewSetDeletionTest(
         self.client.force_authenticate(user=user)
 
         response = self.client.delete(
-            reverse("user-detail", kwargs={"pk": user.pk}), data=data, user=user
+            reverse("user-detail", kwargs={User._meta.pk.name: user.pk}), data=data, user=user
         )
 
         self.assert_status_equal(response, status.HTTP_204_NO_CONTENT)
@@ -108,7 +108,7 @@ class UserViewSetDeletionTest(
         self.client.force_authenticate(user=user)
 
         response = self.client.delete(
-            reverse("user-detail", kwargs={"pk": user.pk}), data=data, user=user
+            reverse("user-detail", kwargs={User._meta.pk.name: user.pk}), data=data, user=user
         )
 
         self.assert_status_equal(response, status.HTTP_400_BAD_REQUEST)
@@ -127,7 +127,7 @@ class UserViewSetDeletionTest(
 
             self.client.force_authenticate(user=user)
             self.client.delete(
-                reverse("user-detail", kwargs={"pk": user.pk}), data=data, user=user
+                reverse("user-detail", kwargs={User._meta.pk.name: user.pk}), data=data, user=user
             )
         override_settings(
             DJOSER=dict(settings.DJOSER, **{"PERMISSIONS": {"user_delete": old_value}})
@@ -147,7 +147,7 @@ class UserViewSetDeletionTest(
 
             self.client.force_authenticate(user=user)
             self.client.delete(
-                reverse("user-detail", kwargs={"pk": user.pk}), data=data, user=user
+                reverse("user-detail", kwargs={User._meta.pk.name: user.pk}), data=data, user=user
             )
         override_settings(
             DJOSER=dict(settings.DJOSER, **{"SERIALIZERS": {"user_delete": old_value}})

--- a/testproject/testapp/tests/test_user_view.py
+++ b/testproject/testapp/tests/test_user_view.py
@@ -17,7 +17,7 @@ class UserViewTest(
     def setUp(self):
         self.user = create_user()
         self.client.force_authenticate(user=self.user)
-        self.url = reverse("user-detail", kwargs={"pk": self.user.pk})
+        self.url = reverse("user-detail", kwargs={User._meta.pk.name: self.user.pk})
 
     def test_get_return_user(self):
         response = self.client.get(self.url)
@@ -62,7 +62,7 @@ class UserViewTest(
             }
         )
         data = {"email": "ringo@beatles.com"}
-        url = reverse("user-detail", kwargs={"pk": other_user.pk})
+        url = reverse("user-detail", kwargs={User._meta.pk.name: other_user.pk})
 
         response = self.client.get(self.url)
         self.assert_status_equal(response, status.HTTP_200_OK)
@@ -81,7 +81,7 @@ class UserViewTest(
             }
         )
         data = {"email": "ringo@beatles.com"}
-        url = reverse("user-detail", kwargs={"pk": other_user.pk})
+        url = reverse("user-detail", kwargs={User._meta.pk.name: other_user.pk})
 
         response = self.client.get(self.url)
         self.assert_status_equal(response, status.HTTP_200_OK)


### PR DESCRIPTION
My project requires primary key field of int(id) and guid field for User model. uuid field will used for only public operations. But currently djoser uses only primary key field. This simple changes make possible to configure the public id field.