### PR TITLE
Use serializer user before request user for password validation

### DIFF
--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -205,7 +205,7 @@ class PasswordSerializer(serializers.Serializer):
     new_password = serializers.CharField(style={"input_type": "password"})
 
     def validate(self, attrs):
-        user = self.context["request"].user or self.user
+        user = getattr(self, 'user', None) or self.context["request"].user
         # why assert? There are ValidationError / fail everywhere
         assert user is not None
 


### PR DESCRIPTION
There will always be a user in the request object.  By default that user is AnonymousUser.  Django has built-in password validation that can valiate from the User object but is moot when validating from the AnonymousUser object.  Switching the order to first use the serializer's user allows for the use of the built-in Django validator django.contrib.auth.password_validation.UserAttributeSimilarityValidator.  Also wrap the self.user in a getattr just in case.