### PR TITLE
Fix base_endpoints.rst User Activate table

### DIFF
--- a/docs/source/base_endpoints.rst
+++ b/docs/source/base_endpoints.rst
@@ -52,7 +52,7 @@ active when calling this endpoint (this will happen if you call it more than onc
 |          |                                      | ``HTTP_400_BAD_REQUEST``         |
 |          |                                      |                                  |
 |          |                                      | * ``uid``                        |
-|          |                                      | * ``token``           |
+|          |                                      | * ``token``                      |
 |          |                                      |                                  |
 |          |                                      | ``HTTP_403_FORBIDDEN``           |
 |          |                                      |                                  |


### PR DESCRIPTION
Correct syntax error that was preventing the table from rendering properly.