### PR TITLE
Fix for CurrentUserOrAdminOrReadOnly permission

### DIFF
--- a/djoser/permissions.py
+++ b/djoser/permissions.py
@@ -8,7 +8,7 @@ class CurrentUserOrAdmin(permissions.IsAuthenticated):
         return user.is_staff or obj.pk == user.pk
 
 
-class CurrentUserOrAdminOrReadOnly(permissions.IsAuthenticated):
+class CurrentUserOrAdminOrReadOnly(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         user = request.user
         if type(obj) == type(user) and obj == user:


### PR DESCRIPTION
The CurrentUserOrAdminOrReadOnly permission should inherit from BasePermission.
The has_object_permission method only runs if the has_permission method has passed validation. Currently the permission will always require the user to be logged in, even if the request method is in SAFE_METHODS.