### PR TITLE
Set Password Issue

### DIFF
--- a/djoser/views.py
+++ b/djoser/views.py
@@ -218,13 +218,13 @@ class UserViewSet(viewsets.ModelViewSet):
         self.request.user.set_password(serializer.data["new_password"])
         self.request.user.save()
 
-        if settings.LOGOUT_ON_PASSWORD_CHANGE:
-            utils.logout_user(self.request)
-
         if settings.PASSWORD_CHANGED_EMAIL_CONFIRMATION:
             context = {"user": self.request.user}
             to = [get_user_email(self.request.user)]
             settings.EMAIL.password_changed_confirmation(self.request, context).send(to)
+
+        if settings.LOGOUT_ON_PASSWORD_CHANGE:
+            utils.logout_user(self.request)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(["post"], detail=False)


### PR DESCRIPTION
There's an issue on the `set_password` view when these three settings set True, all together.
`PASSWORD_CHANGED_EMAIL_CONFIRMATION`,
`LOGOUT_ON_PASSWORD_CHANGE`,
`CREATE_SESSION_ON_LOGIN`

An exception occurred because we log out the user at the first, so `request.user` set to `AnonymousUser`, next we try to send a confirmation email, what happens? can't find `EMAIL_FIELD` in `AnonymousUser` object.