### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,5 +112,5 @@ List of projects related to Django, REST and authentication:
 
 - `django-rest-framework-simplejwt <https://github.com/davesque/django-rest-framework-simplejwt>`_
 - `django-oauth-toolkit <https://github.com/evonove/django-oauth-toolkit>`_
-- `django-rest-auth <https://github.com/Tivix/django-rest-auth>`_
+- `django-rest-auth <https://github.com/Tivix/django-rest-auth>`_ (not maintained)
 - `django-rest-framework-digestauth <https://github.com/juanriaza/django-rest-framework-digestauth>`_ (not maintained)


### PR DESCRIPTION
as stated in https://github.com/Tivix/django-rest-auth/issues/568 , the package `django-rest-auth` is not maintained any more.