### PR TITLE
Add urls.py config documentation for social auth

### DIFF
--- a/docs/source/social_endpoints.rst
+++ b/docs/source/social_endpoints.rst
@@ -28,6 +28,14 @@ The list of providers is available at
 `social backend docs <https://python-social-auth.readthedocs.io/en/latest/backends/index.html#social-backends>`_.
 please follow the instructions provided there to configure your backend.
 
+Configure ``urls.py``:
+
+.. code-block:: python
+
+    urlpatterns = [
+        (...),
+        url(r'^auth/', include('djoser.social.urls')),
+    ]
 
 **Default URL**: ``/o/{{ provider }}/``
 


### PR DESCRIPTION
I had to look at the source code to find the import to get the /o/{{ provider }}/ url working, 
including it in the documentation might help others save some time