### PR TITLE
Fix for Friendly tips when Missing SOCIAL_AUTH_ALLOWED_REDIRECT_URIS

### DIFF
--- a/djoser/social/views.py
+++ b/djoser/social/views.py
@@ -13,7 +13,7 @@ class ProviderAuthView(generics.CreateAPIView):
     def get(self, request, *args, **kwargs):
         redirect_uri = request.GET.get("redirect_uri")
         if redirect_uri not in settings.SOCIAL_AUTH_ALLOWED_REDIRECT_URIS:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+            return Response("Missing SOCIAL_AUTH_ALLOWED_REDIRECT_URIS", status=status.HTTP_400_BAD_REQUEST)
         strategy = load_strategy(request)
         strategy.session_set("redirect_uri", redirect_uri)
 

--- a/djoser/social/views.py
+++ b/djoser/social/views.py
@@ -13,7 +13,7 @@ class ProviderAuthView(generics.CreateAPIView):
     def get(self, request, *args, **kwargs):
         redirect_uri = request.GET.get("redirect_uri")
         if redirect_uri not in settings.SOCIAL_AUTH_ALLOWED_REDIRECT_URIS:
-            return Response("Missing SOCIAL_AUTH_ALLOWED_REDIRECT_URIS", status=status.HTTP_400_BAD_REQUEST)
+            return Response("redirect_uri must be in SOCIAL_AUTH_ALLOWED_REDIRECT_URIS", status=status.HTTP_400_BAD_REQUEST)
         strategy = load_strategy(request)
         strategy.session_set("redirect_uri", redirect_uri)
 


### PR DESCRIPTION
i forget add SOCIAL_AUTH_ALLOWED_REDIRECT_URIS to my config

it return 400 error, i don't know why ,  i pay more time find the issues

so  i add Friendly tips

-- sorry  , my english is not well

and thank you all