### PR TITLE
Travis-ci: added support for ppc64le build along with amd64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,18 @@ dist: xenial
 
 language: python
 
+arch:
+  - amd64
+  - ppc64le
+
 python:
   - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
 
+before_install:
+  - sudo chown -Rvf $USER:$GROUP ~/.cache/pip/wheels
 install:
   - travis_retry pip install -U tox-travis
 


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/djoser/builds/186542267 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!