### PR TITLE
Specified version for djangorestframework

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ requirements manually:
 
 .. code-block:: bash
 
-    $ pip install django djangorestframework
+    $ pip install django djangorestframework==3.11
     $ pip install -r requirements.txt
 
 .. code-block:: bash


### PR DESCRIPTION
As noted in #541, djangorestframework version 3.12+ causes TypeErrors on /user/me and /users/ endpoints. 

I noticed that the tests:
test_put_cant_edit_others_attribute, 
test_patch_cant_edit_others_attribute,  
test_put_cant_edit_others_attribute, 
test_unauthenticated_user_cannot_get_user_detail, 
test_user_cannot_get_other_user_detail, 
test_unauthenticated_user_cannot_list_users, 
test_fail_403_without_permission,
test_fail_404_without_permission
also fail with the same TypeError.

Updating the README to specify to use djangorestframework version 3.11.