### PR TITLE
Update user only sends email confirmation if email field was updated

### DIFF
--- a/djoser/views.py
+++ b/djoser/views.py
@@ -148,9 +148,8 @@ class UserViewSet(viewsets.ModelViewSet):
     def perform_update(self, serializer):
         super().perform_update(serializer)
         user = serializer.instance
-        email = serializer.validated_data.get("email", None)
         # should we send activation email after update?
-        if settings.SEND_ACTIVATION_EMAIL and email is not None:
+        if settings.SEND_ACTIVATION_EMAIL and not user.is_active:
             context = {"user": user}
             to = [get_user_email(user)]
             settings.EMAIL.activation(self.request, context).send(to)

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -148,8 +148,9 @@ class UserViewSet(viewsets.ModelViewSet):
     def perform_update(self, serializer):
         super().perform_update(serializer)
         user = serializer.instance
+        email = serializer.validated_data.get("email", None)
         # should we send activation email after update?
-        if settings.SEND_ACTIVATION_EMAIL:
+        if settings.SEND_ACTIVATION_EMAIL and email is not None:
             context = {"user": user}
             to = [get_user_email(user)]
             settings.EMAIL.activation(self.request, context).send(to)


### PR DESCRIPTION
I was running into a similar (or same) issue as described here https://github.com/sunscrapers/djoser/issues/546. I had SEND_ACTIVATION_EMAIL=True and was updating a user's information that wasn't the email (i.e. first_name, last_name, etc). This resulted in sending an activation email, which doesn't really make sense since the email isn't being updated.

* Update user only sends email confirmation if email field was updated
  * Updating fields other than the email result in NOT sending an activation email
* Keeps functionality of SEND_ACTIVATION_EMAIL
* All tests passed