### PR TITLE
Safe urls in templates

### DIFF
--- a/djoser/templates/email/password_reset.html
+++ b/djoser/templates/email/password_reset.html
@@ -8,7 +8,7 @@
 {% blocktrans %}You're receiving this email because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
 
 {% trans "Please go to the following page and choose a new password:" %}
-{{ protocol }}://{{ domain }}/{{ url }}
+{{ protocol }}://{{ domain }}/{{ url|safe }}
 {% trans "Your username, in case you've forgotten:" %} {{ user.get_username }}
 
 {% trans "Thanks for using our site!" %}
@@ -20,7 +20,7 @@
 <p>{% blocktrans %}You're receiving this email because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}</p>
 
 <p>{% trans "Please go to the following page and choose a new password:" %}</p>
-<a href="{{ protocol }}://{{ domain }}/{{ url }}">{{ protocol }}://{{ domain }}/{{ url }}</a>
+<a href="{{ protocol }}://{{ domain }}/{{ url|safe }}">{{ protocol }}://{{ domain }}/{{ url|safe }}</a>
 <p>{% trans "Your username, in case you've forgotten:" %} <b>{{ user.get_username }}</b></p>
 
 <p>{% trans "Thanks for using our site!" %}</p>

--- a/djoser/templates/email/username_reset.html
+++ b/djoser/templates/email/username_reset.html
@@ -8,7 +8,7 @@
 {% blocktrans %}You're receiving this email because you requested a username reset for your user account at {{ site_name }}.{% endblocktrans %}
 
 {% trans "Please go to the following page and choose a new username:" %}
-{{ protocol }}://{{ domain }}/{{ url }}
+{{ protocol }}://{{ domain }}/{{ url|safe }}
 {% trans "Your username, in case you've forgotten:" %} {{ user.get_username }}
 
 {% trans "Thanks for using our site!" %}
@@ -20,7 +20,7 @@
 <p>{% blocktrans %}You're receiving this email because you requested a username reset for your user account at {{ site_name }}.{% endblocktrans %}</p>
 
 <p>{% trans "Please go to the following page and choose a new username:" %}</p>
-<a href="{{ protocol }}://{{ domain }}/{{ url }}">{{ protocol }}://{{ domain }}/{{ url }}</a>
+<a href="{{ protocol }}://{{ domain }}/{{ url|safe }}">{{ protocol }}://{{ domain }}/{{ url|safe }}</a>
 <p>{% trans "Your username, in case you've forgotten:" %} <b>{{ user.get_username }}</b></p>
 
 <p>{% trans "Thanks for using our site!" %}</p>


### PR DESCRIPTION
Before I made these changes, got emails with `&` replaced with `&amp;` between URL params