### PR TITLE
send activation email only when email is changed

### DIFF
--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -24,10 +24,12 @@ class UserSerializer(serializers.ModelSerializer):
 
     def update(self, instance, validated_data):
         email_field = get_user_email_field_name(User)
+        instance.email_changed = False
         if settings.SEND_ACTIVATION_EMAIL and email_field in validated_data:
             instance_email = get_user_email(instance)
             if instance_email != validated_data[email_field]:
                 instance.is_active = False
+                instance.email_changed = True
                 instance.save(update_fields=["is_active"])
         return super().update(instance, validated_data)
 

--- a/djoser/views.py
+++ b/djoser/views.py
@@ -148,8 +148,8 @@ class UserViewSet(viewsets.ModelViewSet):
     def perform_update(self, serializer):
         super().perform_update(serializer)
         user = serializer.instance
-        # should we send activation email after update?
-        if settings.SEND_ACTIVATION_EMAIL and not user.is_active:
+        # Only send activation email when email is changed
+        if user.email_changed:
             context = {"user": user}
             to = [get_user_email(user)]
             settings.EMAIL.activation(self.request, context).send(to)


### PR DESCRIPTION
Hi! I am using your perfect library for some time and I really thought there are still problems sending redundant emails when a user wants to update his/her info. I changed the code to only send activation email when user tries to change his/her email, as what is done in serializer and used that in views too. This PR is related to #546