### PR TITLE
More permissive version constraint for pytz

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ pytest-cov = {version="^3.0", optional=true}
 pytest-django = {version="^4.5.2", optional=true}
 pytest-pythonpath = {version="^0.7.3", optional=true}
 djet = {version="^0.3.0", optional=true}
-pytz = "^2021.3"
+pytz = ">=2021.3"
 webauthn = {version="<1.0", optional=true}
 
 


### PR DESCRIPTION
As pytz is date-versioned, a caret requirement will mean any new release will be incompatible without first updating this project, preventing users from upgrading pytz if they wish so. This removes that constraint.