### PR TITLE
Move group dev dependencies to dev block

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,15 +49,12 @@ djet = {version="^0.3.0", optional=true}
 pytz = "^2021.3"
 webauthn = {version="<1.0", optional=true}
 
-
-[tool.poetry.group.dev.dependencies]
-pyupgrade = "^2.31.0"
-
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.7.1"
 tox = "^3.20.0"
 babel = "^2.8.0"
 black = "^21.12b0"
+pyupgrade = "^2.31.0"
 
 
 [tool.poetry.extras]


### PR DESCRIPTION
Using groups is a new feature in the latest preview version of poetry but it's not yet released, and still breaks installations (see https://github.com/python-poetry/poetry/issues/4983). The dev dependencies are compatible with both the stable and preview poetry versions.