### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -354,7 +354,7 @@ HIDE_USERS
 
 .. versionadded:: 2.0
 
-If set to True, listing ``/users/`` enpoint by normal user will return only
+If set to True, listing ``/users/`` endpoint by normal user will return only
 that user's profile in the list. Beside that, accessing ``/users/<id>/``
 endpoints by user without proper permission will result in HTTP 404 instead of HTTP 403.
 

--- a/testproject/testapp/tests/test_password_reset_confirm.py
+++ b/testproject/testapp/tests/test_password_reset_confirm.py
@@ -53,7 +53,7 @@ class PasswordResetConfirmViewTest(
         Regression test for https://github.com/sunscrapers/djoser/issues/122
 
         When uid was not correct unicode string, error message was a
-        standard Python error messsage. Now we provide human readable message.
+        standard Python error message. Now we provide human readable message.
         """
         user = create_user()
         data = {


### PR DESCRIPTION
There are small typos in:
- docs/source/settings.rst
- testproject/testapp/tests/test_password_reset_confirm.py

Fixes:
- Should read `message` rather than `messsage`.
- Should read `endpoint` rather than `enpoint`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md