### PR TITLE
Allow supplying extra arguments for serializer

### DIFF
--- a/djoser/views.py
+++ b/djoser/views.py
@@ -132,8 +132,8 @@ class UserViewSet(viewsets.ModelViewSet):
     def get_instance(self):
         return self.request.user
 
-    def perform_create(self, serializer):
-        user = serializer.save()
+    def perform_create(self, serializer, *args, **kwargs):
+        user = serializer.save(*args, **kwargs)
         signals.user_registered.send(
             sender=self.__class__, user=user, request=self.request
         )
@@ -145,8 +145,8 @@ class UserViewSet(viewsets.ModelViewSet):
         elif settings.SEND_CONFIRMATION_EMAIL:
             settings.EMAIL.confirmation(self.request, context).send(to)
 
-    def perform_update(self, serializer):
-        super().perform_update(serializer)
+    def perform_update(self, serializer, *args, **kwargs):
+        super().perform_update(serializer, *args, **kwargs)
         user = serializer.instance
         signals.user_updated.send(
             sender=self.__class__, user=user, request=self.request


### PR DESCRIPTION
Example:

Assumption: User model requires extra arguments when a new user is created

With the current implementation, there's no way to supply these extra arguments without overriding AND duplicating most of perform_create's code
But now, it's possible override perform_create as follows:

def perform_create(self, serializer): # overrides djoser's perform_create
    # some code to get/calculate the required extra arguments for creating the user
    my_required_argument_to_create_a_user = 3.14159
    some_more_args = request.something # say, a dict
    return super().perform_create(serializer,my_required_argument_to_create_a_user=my_required_argument_to_create_a_user, **some_more_args)

------
For consistency, I added the same logic to perform_update.