### PR TITLE
Fix duplicate signals in login_user and logout_user functions.

### DIFF
--- a/djoser/utils.py
+++ b/djoser/utils.py
@@ -17,18 +17,18 @@ def login_user(request, user):
     token, _ = settings.TOKEN_MODEL.objects.get_or_create(user=user)
     if settings.CREATE_SESSION_ON_LOGIN:
         login(request, user)
-    user_logged_in.send(sender=user.__class__, request=request, user=user)
+    else:
+        user_logged_in.send(sender=user.__class__, request=request, user=user)
     return token
 
 
 def logout_user(request):
     if settings.TOKEN_MODEL:
         settings.TOKEN_MODEL.objects.filter(user=request.user).delete()
-        user_logged_out.send(
-            sender=request.user.__class__, request=request, user=request.user
-        )
     if settings.CREATE_SESSION_ON_LOGIN:
         logout(request)
+    else:
+        user_logged_out.send(sender=request.user.__class__, request=request, user=request.user)
 
 
 class ActionViewMixin:


### PR DESCRIPTION
When setting "CREATE_SESSION_ON_LOGIN" is on, the signal "user_logged_in" is being sent duplicate, because function login (called in the line 19) already send this signal (/django/contrib/auth/__init__.py line 125).

We have the same situation for logout, function logout (called in the line 29) already send the user_logged_out signal.