### PR TITLE
Use this endpoint to activate user account.

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -6,7 +6,7 @@ Available endpoints
 
 * ``/users/``
 * ``/users/me/``
-* ``/users/confirm/``
+* ``/users/activation/``
 * ``/users/resend_activation/``
 * ``/users/set_password/``
 * ``/users/reset_password/``


### PR DESCRIPTION
This url `/users/confirm/` doesn't work.