### PR TITLE
czech (cs) translation, initial

### DIFF
--- a/djoser/locale/cs/LC_MESSAGES/django.po
+++ b/djoser/locale/cs/LC_MESSAGES/django.po
@@ -1,0 +1,130 @@
+# Copyright (C) Sunscrapers
+# This file is distributed under the same license as the djoser package.
+#
+# Translators:
+# Bertram Bühner <github@sheepyhollow.de>, 2020
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: djoser\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-01-13 17:40+0100\n"
+"PO-Revision-Date: \n"
+"Last-Translator: Mirek Zvolský <zvolsky@seznam.cz>\n"
+"Language-Team: Czech\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#: constants.py:4
+msgid "Unable to log in with provided credentials."
+msgstr "Přihlášení není se zadanými údaji možné."
+
+#: constants.py:5
+msgid "User account is disabled."
+msgstr "Tento účet uživatele není aktivní."
+
+#: constants.py:6
+msgid "Invalid token for given user."
+msgstr "Token není pro tohoto uživatele platný."
+
+#: constants.py:7
+msgid "Invalid user id or user doesn't exist."
+msgstr "Chybné id uživatele, uživatel neexistuje."
+
+#: constants.py:8
+msgid "Stale token for given user."
+msgstr "Tokenu tohoto uživatele vypršela platnost."
+
+#: constants.py:9
+msgid "The two password fields didn't match."
+msgstr "Heslo z kontrolního pole není stejné."
+
+#: constants.py:10
+#, python-brace-format
+msgid "The two {0} fields didn't match."
+msgstr "Obě {0} pole nejsou shodné."
+
+#: constants.py:11
+msgid "Invalid password."
+msgstr "Heslo není správné."
+
+#: constants.py:12
+msgid "User with given email does not exist."
+msgstr "Neexistuje uživatel s takovou mailovou adresou."
+
+#: constants.py:13
+msgid "Unable to create account."
+msgstr "Nepovedlo se založit účet uživatele."
+
+#: constants.py:15
+msgid ""
+"User model does not contain specified email field. Please see http://djoser."
+"readthedocs.io/en/latest/settings.html#USER_EMAIL_FIELD_NAME for more details."
+msgstr ""
+"Model User nemá pole pro E-Mail. Další podrobnosti najdete na http://djoser."
+"readthedocs.io/en/latest/settings.html#USER_EMAIL_FIELD_NAME ."
+
+#: templates/email/activation.html:4
+#, python-format
+msgid "Account activation on %(site_name)s"
+msgstr "Aktivace účtu uživatele na %(site_name)s"
+
+#: templates/email/activation.html:8 templates/email/activation.html:19
+#, python-format
+msgid ""
+"You're receiving this email because you need to finish activation process on "
+"%(site_name)s."
+msgstr ""
+"Tento e-mail jste obdrželi, abyste dokončili proces registrace a aktivace účtu na "
+"%(site_name)s."
+
+#: templates/email/activation.html:10 templates/email/activation.html:22
+msgid "Please go to the following page to activate account:"
+msgstr "Prosím, přejděte na následující stránku, čímž dokončíte aktivaci:"
+
+#: templates/email/activation.html:13 templates/email/activation.html:25
+#: templates/email/confirmation.html:10 templates/email/confirmation.html:18
+#: templates/email/password_reset.html:14 templates/email/password_reset.html:26
+msgid "Thanks for using our site!"
+msgstr "Děkujeme, že používáte naše stránky."
+
+#: templates/email/activation.html:15 templates/email/activation.html:27
+#: templates/email/confirmation.html:12 templates/email/confirmation.html:20
+#: templates/email/password_reset.html:16 templates/email/password_reset.html:28
+#, python-format
+msgid "The %(site_name)s team"
+msgstr "Váš %(site_name)s team"
+
+#: templates/email/confirmation.html:4
+#, python-format
+msgid "%(site_name)s - Your account has been successfully created and activated!"
+msgstr "%(site_name)s - Váš účet uživatele byl úspěšně vytvořen a aktivován."
+
+#: templates/email/confirmation.html:8 templates/email/confirmation.html:16
+msgid "Your account has been created and is ready to use!"
+msgstr "Váš účet uživatele byl vytvořen a je připraven pro použití."
+
+#: templates/email/password_reset.html:4
+#, python-format
+msgid "Password reset on %(site_name)s"
+msgstr "Reset hesla na stránce %(site_name)s"
+
+#: templates/email/password_reset.html:8 templates/email/password_reset.html:20
+#, python-format
+msgid ""
+"You're receiving this email because you requested a password reset for your user "
+"account at %(site_name)s."
+msgstr ""
+"Tento e-mail jste obdrželi, protože zamýšlíte resetovat své heslo na %(site_name)s."
+
+#: templates/email/password_reset.html:10 templates/email/password_reset.html:22
+msgid "Please go to the following page and choose a new password:"
+msgstr "Prosím přejděte na následující stránku a na ní si zvolte nové heslo:"
+
+#: templates/email/password_reset.html:12 templates/email/password_reset.html:24
+msgid "Your username, in case you've forgotten:"
+msgstr "Vaše jméno uživatele, pro případ, že si ho nepamatujete, je:"


### PR DESCRIPTION
Just a new language (cs) translation.

It is a little unsure if cs_CZ or cs should be used, but czech language is used in Czech Rep. only (except of really ultra small minorities in Romania, Serbia (or maybe Swiss or USA)).
So cs is I think the proper way to go.
And it is compatible with Django and Django Admin - this is probably the 1st point.

Best regards.
Mirek Zvolský