### PR TITLE
actually use USER_ID_FIELD in some places it wasnt used

### DIFF
--- a/djoser/email.py
+++ b/djoser/email.py
@@ -13,7 +13,7 @@ class ActivationEmail(BaseEmailMessage):
         context = super().get_context_data()
 
         user = context.get("user")
-        context["uid"] = utils.encode_uid(user.pk)
+        context["uid"] = utils.encode_uid(getattr(user, settings.USER_ID_FIELD))
         context["token"] = default_token_generator.make_token(user)
         context["url"] = settings.ACTIVATION_URL.format(**context)
         return context
@@ -31,7 +31,7 @@ class PasswordResetEmail(BaseEmailMessage):
         context = super().get_context_data()
 
         user = context.get("user")
-        context["uid"] = utils.encode_uid(user.pk)
+        context["uid"] = utils.encode_uid(getattr(user, settings.USER_ID_FIELD))
         context["token"] = default_token_generator.make_token(user)
         context["url"] = settings.PASSWORD_RESET_CONFIRM_URL.format(**context)
         return context
@@ -52,7 +52,7 @@ class UsernameResetEmail(BaseEmailMessage):
         context = super().get_context_data()
 
         user = context.get("user")
-        context["uid"] = utils.encode_uid(user.pk)
+        context["uid"] = utils.encode_uid(getattr(user, settings.USER_ID_FIELD))
         context["token"] = default_token_generator.make_token(user)
         context["url"] = settings.USERNAME_RESET_CONFIRM_URL.format(**context)
         return context

--- a/djoser/serializers.py
+++ b/djoser/serializers.py
@@ -177,7 +177,7 @@ class UidAndTokenSerializer(serializers.Serializer):
         # doesn't work with modelserializer
         try:
             uid = utils.decode_uid(self.initial_data.get("uid", ""))
-            self.user = User.objects.get(pk=uid)
+            self.user = User.objects.get(**{settings.USER_ID_FIELD: uid})
         except (User.DoesNotExist, ValueError, TypeError, OverflowError):
             key_error = "invalid_uid"
             raise ValidationError(


### PR DESCRIPTION
Make usage of USER_ID_FIELD more consistent
right now using an id that is not strictly the `pk` field make email templates fail because they follow the USER_ID_FIELD, while the endpoints expect strictly a pk without regard to the `USER_ID_FIELD` configured in the settings.

it "may" be a breaking change, but it should be a lot more correct, so I'm not completely sure wether or not you should merge this (at least I needed it for my project, and it would be easier for me to merge this rather than have to maintain a fork)