### PR TITLE
Update authentication_backends.rst to use the recent path() method, i…

### DIFF
--- a/docs/source/authentication_backends.rst
+++ b/docs/source/authentication_backends.rst
@@ -30,8 +30,8 @@ Configure ``urls.py``. Pay attention to ``djoser.url.authtoken`` module path:
 
     urlpatterns = [
         (...),
-        url(r'^auth/', include('djoser.urls')),
-        url(r'^auth/', include('djoser.urls.authtoken')),
+        path('auth/', include(djoser_urls)),
+        path('auth/', include(authtoken_urls)),
     ]
 
 Add ``rest_framework.authentication.TokenAuthentication`` to Django REST Framework


### PR DESCRIPTION
…nstead of the url() method

The url() method is no longer common, as a junior dev in python and django i was surprised to see the use of url() for declaring djoser path as I am more familiar with the path(). The some study on which is most common and realised that of path is more up to date and should also be more frequent this days, so I felt it would be great if djoser docks is updated to use the most recent path() instead as it eliminates the regex start flage (^) and the use of raw string , which looks a bit more complex to a rookie like myself.