### PR TITLE
Replace url() with re_path() in the docs

### DIFF
--- a/docs/source/adjustment.rst
+++ b/docs/source/adjustment.rst
@@ -12,7 +12,7 @@ Define custom ``urls`` instead of reusing ``djoser.urls``:
 
     urlpatterns = patterns('',
         (...),
-        url(r'^register/$', views.CustomRegistrationView.as_view()),
+        re_path(r'^register/$', views.CustomRegistrationView.as_view()),
     )
 
 Define custom view/serializer (inherit from one of ``djoser`` class) and override necessary method/field:

--- a/docs/source/authentication_backends.rst
+++ b/docs/source/authentication_backends.rst
@@ -30,8 +30,8 @@ Configure ``urls.py``. Pay attention to ``djoser.url.authtoken`` module path:
 
     urlpatterns = [
         (...),
-        url(r'^auth/', include('djoser.urls')),
-        url(r'^auth/', include('djoser.urls.authtoken')),
+        re_path(r'^auth/', include('djoser.urls')),
+        re_path(r'^auth/', include('djoser.urls.authtoken')),
     ]
 
 Add ``rest_framework.authentication.TokenAuthentication`` to Django REST Framework
@@ -89,6 +89,6 @@ Configure ``urls.py`` with ``djoser.url.jwt`` module path:
 
     urlpatterns = [
         (...),
-        url(r'^auth/', include('djoser.urls')),
-        url(r'^auth/', include('djoser.urls.jwt')),
+        re_path(r'^auth/', include('djoser.urls')),
+        re_path(r'^auth/', include('djoser.urls.jwt')),
     ]

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -76,7 +76,7 @@ Configure ``urls.py``:
 
     urlpatterns = [
         (...),
-        url(r'^auth/', include('djoser.urls')),
+        re_path(r'^auth/', include('djoser.urls')),
     ]
 
 HTTP Basic Auth strategy is assumed by default as Django Rest Framework does it.

--- a/docs/source/social_endpoints.rst
+++ b/docs/source/social_endpoints.rst
@@ -34,7 +34,7 @@ Configure ``urls.py``:
 
     urlpatterns = [
         (...),
-        url(r'^auth/', include('djoser.social.urls')),
+        re_path(r'^auth/', include('djoser.social.urls')),
     ]
 
 **Default URL**: ``/o/{{ provider }}/``

--- a/docs/source/webauthn.rst
+++ b/docs/source/webauthn.rst
@@ -29,7 +29,7 @@ Add ``djoser.webauthn.urls`` url patterns to ``urls.py``:
 
     urlpatterns = [
         (...),
-        url(r'^auth/webauthn/', include('djoser.webauthn.urls')),
+        re_path(r'^auth/webauthn/', include('djoser.webauthn.urls')),
     ]
 
 


### PR DESCRIPTION
url() is deprecated and has been removed in Django v4