### PR TITLE
Allow dynamic serializer configuration via settings

### DIFF
--- a/djoser/conf.py
+++ b/djoser/conf.py
@@ -62,6 +62,7 @@ default_settings = {
             "current_user": "djoser.serializers.UserSerializer",
             "token": "djoser.serializers.TokenSerializer",
             "token_create": "djoser.serializers.TokenCreateSerializer",
+            "provider_auth": "djoser.social.serializers.ProviderAuthSerializer",
         }
     ),
     "EMAIL": ObjDict(

--- a/djoser/social/views.py
+++ b/djoser/social/views.py
@@ -3,12 +3,11 @@ from rest_framework.response import Response
 from social_django.utils import load_backend, load_strategy
 
 from djoser.conf import settings
-from djoser.social.serializers import ProviderAuthSerializer
 
 
 class ProviderAuthView(generics.CreateAPIView):
     permission_classes = [permissions.AllowAny]
-    serializer_class = ProviderAuthSerializer
+    serializer_class = settings.SERIALIZERS.provider_auth
 
     def get(self, request, *args, **kwargs):
         redirect_uri = request.GET.get("redirect_uri")


### PR DESCRIPTION
- Added support for configuring serializers through settings: "SERIALIZERS" dictionary in djoser settings. Specifically added "provider_auth": "djoser.social.serializers.ProviderAuthSerializer".
- Updated `ProviderAuthView` to use the dynamic serializer: `serializer_class = settings.SERIALIZERS.provider_auth`