### PR TITLE
Chore: Add TokenBlacklistView to JWT URLs

### DIFF
--- a/djoser/urls/jwt.py
+++ b/djoser/urls/jwt.py
@@ -5,5 +5,7 @@ urlpatterns = [
     re_path(r"^jwt/create/?", views.TokenObtainPairView.as_view(), name="jwt-create"),
     re_path(r"^jwt/refresh/?", views.TokenRefreshView.as_view(), name="jwt-refresh"),
     re_path(r"^jwt/verify/?", views.TokenVerifyView.as_view(), name="jwt-verify"),
-    re_path(r"^jwt/blacklist/?", views.TokenBlacklistView.as_view(), name="jwt-verify"),
+    re_path(
+        r"^jwt/blacklist/?", views.TokenBlacklistView.as_view(), name="jwt-blacklist"
+    ),
 ]

--- a/djoser/urls/jwt.py
+++ b/djoser/urls/jwt.py
@@ -5,4 +5,5 @@ urlpatterns = [
     re_path(r"^jwt/create/?", views.TokenObtainPairView.as_view(), name="jwt-create"),
     re_path(r"^jwt/refresh/?", views.TokenRefreshView.as_view(), name="jwt-refresh"),
     re_path(r"^jwt/verify/?", views.TokenVerifyView.as_view(), name="jwt-verify"),
+    re_path(r"^jwt/blacklist/?", views.TokenBlacklistView.as_view(), name="jwt-verify"),
 ]


### PR DESCRIPTION
This pull request adds support for blacklisting JWT refresh tokens in the Djoser authentication package, which integrates with Django Rest Framework's SimpleJWT package.

By default, Djoser supports JWT token obtain and refresh functionalities. However, in certain scenarios, it is necessary to invalidate refresh tokens. To address this, I have added a new URL pattern to support the blacklisting of refresh tokens:

```
re_path(r"^jwt/blacklist/?", views.TokenBlacklistView.as_view(), name="jwt-blacklist"),
```

Changes:
Added TokenBlacklistView to JWT URLs to handle refresh token blacklisting.

Documentation:
To ensure proper functionality, it is essential to update the documentation to include the following addition to the INSTALLED_APPS setting in Django:

```
INSTALLED_APPS = (
    ...
    'rest_framework_simplejwt.token_blacklist',
    ...
)
```