### PR TITLE
Fix/get user model: from `settings.AUTH_USER_MODEL` to `.get_user_model`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,7 @@ To run the test just type:
 
 .. code-block:: bash
 
+    $ cd testproject
     $ poetry run pytest
 
 We also prepared a convenient ``Makefile`` to automate commands above:

--- a/djoser/conf.py
+++ b/djoser/conf.py
@@ -1,5 +1,5 @@
 # flake8: noqa E501
-from django.apps import apps
+from django.contrib.auth import get_user_model
 from django.conf import settings as django_settings
 from django.test.signals import setting_changed
 from django.utils.functional import LazyObject
@@ -7,9 +7,7 @@ from django.utils.module_loading import import_string
 
 DJOSER_SETTINGS_NAMESPACE = "DJOSER"
 
-auth_module, user_model = django_settings.AUTH_USER_MODEL.rsplit(".", 1)
-
-User = apps.get_model(auth_module, user_model)
+User = get_user_model()
 
 
 class ObjDict(dict):


### PR DESCRIPTION
Since Django 1.11, get_user_model() actually uses settings.AUTH_USER_MODEL
> see https://docs.djangoproject.com/en/5.2/topics/auth/customizing/#django.contrib.auth.get_user_model

### Readme

- explained better how to test djoser with poetry