### PR TITLE
Release 2.3.4a1: publish from CI with an API token

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "ask": [
+      "Bash(git tag -d*)",
+      "Bash(git tag --delete*)",
+      "Bash(git gc --prune*)",
+      "Bash(git prune*)",
+      "Bash(git update-ref -d*)",
+      "Bash(git remote remove*)",
+      "Bash(git remote rm*)",
+      "Bash(git remote set-url*)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,7 @@
       "Bash(git tag --delete*)",
       "Bash(git gc --prune*)",
       "Bash(git prune*)",
+      "Bash(git push --delete*)",
       "Bash(git update-ref -d*)",
       "Bash(git remote remove*)",
       "Bash(git remote rm*)",

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -28,8 +28,9 @@ checked before the tag exists.
    version number:
    - patch = bug fixes, minor = backwards-compatible features,
      major = breaking changes
-   - a PEP 440 pre-release suffix (`a1`, `b1`, `rc1`) publishes to Test PyPI
-     instead of PyPI; suggest an `rc` first when the diff is large or risky
+   - a PEP 440 pre-release suffix (`a1`, `b1`, `rc1`) publishes to PyPI like
+     any other version, but pip/uv never resolve to it without `--pre` or an
+     exact pin; suggest one first when the diff is large or risky
 5. If there is nothing user-facing to release, say so and stop.
 
 ## 2. Prepare the release branch

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -30,7 +30,9 @@ checked before the tag exists.
      major = breaking changes
    - a PEP 440 pre-release suffix (`a1`, `b1`, `rc1`) publishes to PyPI like
      any other version, but pip/uv never resolve to it without `--pre` or an
-     exact pin; suggest one first when the diff is large or risky
+     exact pin; suggest one first when the diff is large or risky. Write the
+     changelog entry under the final `X.Y.Z` heading — CI falls back to it for
+     the pre-release, and the changelog carries no pre-release sections.
 5. If there is nothing user-facing to release, say so and stop.
 
 ## 2. Prepare the release branch
@@ -49,6 +51,10 @@ checked before the tag exists.
      entry may be missing from the diff
    - the CI extracts this section verbatim as the GitHub release notes, and
      fails a stable release if the section is missing
+   - `docs/source/changelog.rst` includes this file, so the entry is also
+     published on Read the Docs — there is no second place to edit, but the
+     entry must be valid RST (escape `` ``**kwargs`` ``-style markup) or the
+     docs build warns and renders it wrong
 4. Show the changelog entry to the user and get approval before continuing.
 
 ## 3. Verify locally
@@ -59,6 +65,8 @@ Run all of these; all must pass:
 2. `make run-hooks` — pre-commit checks (needs `.venv/bin` on `PATH`)
 3. `make build` — translations compile and the package builds
 4. `uv lock --check` — lockfile consistent with `pyproject.toml`
+5. `make docs` — the docs build, including the rendered changelog entry;
+   it must not add new warnings
 
 Report the results honestly; a failure here aborts the release until fixed.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,18 +57,23 @@ jobs:
       - name: Extract release notes from CHANGELOG.rst
         run: |
           VERSION="${{ steps.meta.outputs.version }}"
-          awk -v ver="$VERSION" '
-            index($0, "`" ver "`_") == 1 { found=1; getline; next }
-            found && /^-+$/ { exit }
-            found { print }
-          ' CHANGELOG.rst > release-notes.md
+          extract_section() {
+            awk -v ver="$1" '
+              index($0, "`" ver "`_") == 1 { found=1; getline; next }
+              found && /^-+$/ { exit }
+              found { print }
+            ' CHANGELOG.rst
+          }
+          extract_section "$VERSION" > release-notes.md
+          if ! grep -q '[^[:space:]]' release-notes.md && [ "${{ steps.meta.outputs.prerelease }}" = "true" ]; then
+            # The changelog only carries final versions, so a pre-release reads
+            # the section of the version it is a candidate for.
+            BASE=$(printf '%s' "$VERSION" | sed -E 's/(a|b|rc)[0-9]+$//')
+            { echo "Pre-release of $BASE."; echo; extract_section "$BASE"; } > release-notes.md
+          fi
           if ! grep -q '[^[:space:]]' release-notes.md; then
-            if [ "${{ steps.meta.outputs.prerelease }}" = "true" ]; then
-              echo "Pre-release $VERSION" > release-notes.md
-            else
-              echo "No CHANGELOG.rst entry found for $VERSION. Add release notes before tagging."
-              exit 1
-            fi
+            echo "No CHANGELOG.rst entry found for $VERSION. Add release notes before tagging."
+            exit 1
           fi
           echo "Release notes:"
           cat release-notes.md
@@ -120,9 +125,10 @@ jobs:
           name: dist
           path: dist/
 
-  # Pre-releases publish to PyPI too: pip and uv never resolve a pre-release
-  # version unless asked with --pre or an exact pin, so an aN/bN/rcN upload is
-  # invisible to ordinary installs while still exercising the real pipeline.
+  # Every version publishes to PyPI, pre-releases included: pip and uv never
+  # resolve a pre-release unless asked with --pre or an exact pin, so an
+  # aN/bN/rcN upload is invisible to ordinary installs while still exercising
+  # the real publish path. Test PyPI is deliberately not used.
   publish-pypi:
     name: Publish to PyPI
     needs: [validate, tests, build]
@@ -130,8 +136,6 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/djoser/
-    permissions:
-      id-token: write
     steps:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -143,7 +147,14 @@ jobs:
           path: dist
 
       - name: Publish
-        run: uv publish --trusted-publishing always dist/*
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          if [ -z "$UV_PUBLISH_TOKEN" ]; then
+            echo "The PYPI_TOKEN secret is not set on this repository."
+            exit 1
+          fi
+          uv publish dist/*
 
   github-release:
     name: Create GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,32 +120,11 @@ jobs:
           name: dist
           path: dist/
 
-  publish-testpypi:
-    name: Publish to Test PyPI
-    if: needs.validate.outputs.prerelease == 'true'
-    needs: [validate, tests, build]
-    runs-on: ubuntu-latest
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/djoser/
-    permissions:
-      id-token: write
-    steps:
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Download distribution
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist
-
-      - name: Publish
-        run: uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always dist/*
-
+  # Pre-releases publish to PyPI too: pip and uv never resolve a pre-release
+  # version unless asked with --pre or an exact pin, so an aN/bN/rcN upload is
+  # invisible to ordinary installs while still exercising the real pipeline.
   publish-pypi:
     name: Publish to PyPI
-    if: needs.validate.outputs.prerelease == 'false'
     needs: [validate, tests, build]
     runs-on: ubuntu-latest
     environment:
@@ -168,9 +147,7 @@ jobs:
 
   github-release:
     name: Create GitHub release
-    needs: [validate, publish-testpypi, publish-pypi]
-    # exactly one of the publish jobs runs; succeed when that one succeeded
-    if: always() && needs.validate.result == 'success' && (needs.publish-testpypi.result == 'success' || needs.publish-pypi.result == 'success')
+    needs: [validate, publish-pypi]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ This document records all notable changes to djoser.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 ---------------------
+`2.3.4`_ (2026-08-01)
+---------------------
+
+* return ``404 Not Found`` instead of an unhandled server error when requesting social authentication for a provider that is not configured https://github.com/sunscrapers/djoser/pull/893
+* return ``400 Bad Request`` instead of a server error when the social auth provider is unreachable while completing authentication https://github.com/sunscrapers/djoser/pull/893
+
+---------------------
 `2.3.3`_ (2025-07-13)
 ---------------------
 
@@ -159,7 +166,7 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 * Added endpoint to resend activation email.
 * Added Polish and Georgian translations.
-* Fix missing **kwargs in ActionViewmixin.post() handler.
+* Fix missing ``**kwargs`` in ActionViewmixin.post() handler.
 * Fixed documentation.
 * Other small fixes.
 
@@ -477,3 +484,4 @@ few bugfixes / documentation updates. List of changes:
 .. _2.3.1: https://github.com/sunscrapers/djoser/compare/2.3.0...2.3.1
 .. _2.3.2: https://github.com/sunscrapers/djoser/compare/2.3.1...2.3.2
 .. _2.3.3: https://github.com/sunscrapers/djoser/compare/2.3.2...2.3.3
+.. _2.3.4: https://github.com/sunscrapers/djoser/compare/2.3.3...2.3.4

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -90,14 +90,16 @@ Pushing a tag triggers the `Release` workflow, which:
      anything else fails validation and nothing is built
    - `pyproject.toml` version matches the tag
    - stable tags point at a commit that is on `master`
-   - `CHANGELOG.rst` contains a section for the version (required for stable
-     releases; optional for pre-releases) — it becomes the release notes
+   - `CHANGELOG.rst` contains a section for the version — a pre-release falls
+     back to the section of the version it is a candidate for, so `2.3.4rc1`
+     uses the `2.3.4` entry and the changelog never carries pre-release
+     headings; the section becomes the release notes
 2. **Runs the full test suite** (the same matrix as `test-suite.yml`)
 3. **Compiles** translations (`pybabel compile`) and **builds** the package
    (`uv build`)
-4. **Publishes** the built distribution to PyPI (`pypi` environment) — both
-   stable releases and pre-releases; the GitHub release is marked as a
-   pre-release for the latter
+4. **Publishes** the built distribution to PyPI (`pypi` environment) — every
+   version, pre-release or stable; the GitHub release is marked as a
+   pre-release for the former
 5. **Creates the GitHub release** with the changelog section as its notes and
    the built distribution attached (only after publishing succeeded)
 
@@ -120,16 +122,18 @@ to you.
 
 ## One-Time Setup
 
-The pipeline authenticates to PyPI with [trusted publishing](https://docs.pypi.org/trusted-publishers/)
-(OIDC) — no API tokens are stored in GitHub secrets. It has to be configured
-once:
+The pipeline authenticates to PyPI with the `PYPI_TOKEN` Actions secret — a
+PyPI API token with upload rights to the `djoser` project. Scope it to the
+project rather than the whole account, so a leak cannot be used to publish
+other packages. The publish step fails with an explicit message when the secret
+is missing, rather than a bare 403.
 
-- On [PyPI](https://pypi.org/manage/project/djoser/settings/publishing/) add a
-  trusted publisher: owner `sunscrapers`, repository `djoser`, workflow
-  `release.yml`, environment `pypi`
-- The `pypi` GitHub environment is created automatically on the first run;
-  optionally add required reviewers to it to get a manual approval gate
-  before publishing
+Test PyPI is not used: pre-releases are published to PyPI itself, where pip and
+uv will not install them by default (see Notes).
+
+The `pypi` GitHub environment is created automatically on the first run;
+optionally add required reviewers to it to get a manual approval gate before
+publishing.
 
 ## Notes
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -95,9 +95,9 @@ Pushing a tag triggers the `Release` workflow, which:
 2. **Runs the full test suite** (the same matrix as `test-suite.yml`)
 3. **Compiles** translations (`pybabel compile`) and **builds** the package
    (`uv build`)
-4. **Publishes** the built distribution:
-   - Pre-releases → Test PyPI (`testpypi` environment)
-   - Stable releases → PyPI (`pypi` environment)
+4. **Publishes** the built distribution to PyPI (`pypi` environment) — both
+   stable releases and pre-releases; the GitHub release is marked as a
+   pre-release for the latter
 5. **Creates the GitHub release** with the changelog section as its notes and
    the built distribution attached (only after publishing succeeded)
 
@@ -122,23 +122,24 @@ to you.
 
 The pipeline authenticates to PyPI with [trusted publishing](https://docs.pypi.org/trusted-publishers/)
 (OIDC) — no API tokens are stored in GitHub secrets. It has to be configured
-once per index:
+once:
 
 - On [PyPI](https://pypi.org/manage/project/djoser/settings/publishing/) add a
   trusted publisher: owner `sunscrapers`, repository `djoser`, workflow
   `release.yml`, environment `pypi`
-- On [Test PyPI](https://test.pypi.org/manage/project/djoser/settings/publishing/)
-  add the same with environment `testpypi`
-- In the GitHub repository settings, create the `pypi` and `testpypi`
-  environments; optionally add required reviewers to `pypi` to get a manual
-  approval gate before publishing
+- The `pypi` GitHub environment is created automatically on the first run;
+  optionally add required reviewers to it to get a manual approval gate
+  before publishing
 
 ## Notes
 
 - The `release.yml` workflow handles the entire release: validation, tests,
   build, PyPI upload and the GitHub release
 - Translations are automatically compiled during the release process
-- Test PyPI is used for pre-releases to validate the packaging
+- Pre-releases (`aN`/`bN`/`rcN`) are published to PyPI like any other version,
+  but `pip install djoser` and `uv add djoser` never resolve to them — only an
+  explicit `--pre` or an exact pin (`djoser==X.Y.ZaN`) installs one, which
+  makes them a safe way to validate a release end to end
 
 ## Troubleshooting
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,4 @@
+.. This page renders the repository CHANGELOG.rst so the published docs carry
+   the release history. Edit CHANGELOG.rst at the repository root, not here.
+
+.. include:: ../../CHANGELOG.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,6 +36,7 @@ Welcome to djoser's documentation!
     :caption: Usage
 
     migration_guide
+    changelog
 
 Indices and tables
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "djoser"
-version = "2.3.3"
+version = "2.3.4a1"
 description = "REST implementation of Django authentication system."
 authors = [
     {name = "Sunscrapers", email = "info@sunscrapers.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "djoser"
-version = "2.3.3"
+version = "2.3.4a1"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "4.2.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Prepares the `2.3.4a1` pre-release, switches release publishing to token auth, and gives the docs a changelog.

## Publishing: back to the `PYPI_TOKEN` secret

PR #888 moved publishing to PyPI trusted publishing (OIDC). That needs a one-time publisher registration on PyPI that was never done, so the first real attempt (tag `2.3.4rc1`) failed with `invalid-publisher` after everything else had passed. This reverts to the `PYPI_TOKEN` secret, which already exists and has published every djoser release to date. The publish step fails with an explicit message if the secret is ever missing, instead of a bare 403.

## Test PyPI is dropped

It has never been published to from CI:

- `publish_pypi.yml` ran 3 times, all stable releases (2.3.2, 2.3.3)
- no GitHub release in the repo's history has ever been flagged as a pre-release, so the `if: github.event.release.prerelease` steps never ran
- no `TEST_PYPI_TOKEN` exists as a repo or environment secret
- the newest djoser on test.pypi.org is **0.7.0, uploaded 2017-09-01**, from the manual setup.py/twine era

Rather than keep an unreachable job, pre-releases publish to PyPI itself. `pip install djoser` and `uv add djoser` never resolve to a pre-release — only `--pre` or an exact pin (`djoser==2.3.4a1`) installs one — so an alpha is invisible to ordinary users while still exercising the real publish path.

## Release notes

The changelog now carries a `2.3.4` entry (the two social-auth fixes from #893). A pre-release tag falls back to the section of the version it is a candidate for, so `2.3.4a1` publishes with the `2.3.4` notes and the changelog never accumulates `aN`/`bN`/`rcN` headings.

## Docs get a changelog

`CHANGELOG.rst` was never referenced anywhere under `docs/`, so the published site has never shown a release history — for any version. A stub page includes it, keeping the root file the single source of truth. Rendering it surfaced a latent unterminated bold marker (bare `**kwargs`) in the 1.5.0 entry, now fixed. `make docs` joins the release skill's local verification gates.

## Also

- `.claude/settings.json` is now tracked, requiring confirmation before commands that delete refs or prune unreachable objects.
- Version bumped to `2.3.4a1` + `uv lock`.

## Verified locally

- `make test` — 206 passed, 99% coverage
- `make run-hooks` — all hooks pass
- `make build` — builds `djoser-2.3.4a1`, all 13 `django.mo` catalogs in the wheel
- `uv lock --check` — clean
- `make docs` — builds at the pre-existing 6-warning baseline; release-note extraction verified for both the `2.3.4a1` and `2.3.4` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUccbzSjBjZYvJtzbLjLo7