### PR TITLE
Bump version to 2.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "djoser"
-version = "2.3.4a1"
+version = "2.3.4"
 description = "REST implementation of Django authentication system."
 authors = [
     {name = "Sunscrapers", email = "info@sunscrapers.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "djoser"
-version = "2.3.4a1"
+version = "2.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "4.2.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Promotes `2.3.4a1` to the stable `2.3.4` release.

Only `pyproject.toml` and `uv.lock` change — the `2.3.4` changelog entry and its compare link already landed with the alpha, and today's date still matches the entry, so nothing there needed touching.

## What 2.3.4 contains

Two social-auth error-handling fixes (#893), confirmed by diffing the published 2.3.4a1 wheel against 2.3.3 — those are the only two library modules whose contents changed:

* `ProviderAuthView` returns `404 Not Found` for an unconfigured provider instead of letting `MissingBackend` surface as a 500
* `ProviderAuthSerializer` returns `400 Bad Request` when the provider is unreachable, instead of a 500

Everything else since 2.3.3 is tooling: the poetry→uv migration (#888) and the release pipeline (#917).

## The alpha validated the pipeline and the artifact

`2.3.4a1` published to PyPI cleanly (run 30706165230, all 32 jobs green). Comparing it against 2.3.3 as downloaded from PyPI:

- all 32 Python modules at identical paths, only the two social modules differing by hash
- all 13 locales present with compiled `.mo`; catalogs decode to **zero message differences** (only the `Generated-By: Babel` header stamp moved)
- all 6 dependencies semantically identical (parsed with `packaging`, not text-diffed), all 19 classifiers unchanged
- wheel structure identical; `LICENSE` relocated to `dist-info/licenses/` per PEP 639

Two intentional metadata deltas carried over from the hatchling switch: `Requires-Python` is now `>=3.9` (poetry's synthesized `<4.0` cap is gone) and the sdist includes a top-level `.gitignore`.

## Verified locally

- `make test` — 206 passed, 99% coverage
- `make run-hooks` — all hooks pass
- `make build` — builds `djoser-2.3.4`, 13 `django.mo` catalogs in both wheel and sdist
- `uv lock --check` — clean
- `make docs` — 6 warnings, the pre-existing baseline
- release-note extraction for tag `2.3.4` returns the correct section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUccbzSjBjZYvJtzbLjLo7