### PR TITLE
Drop the unused djet extra

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -37,7 +37,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --group test --extra djet --extra webauthn
+        run: uv sync --group test --extra webauthn
 
       - name: Install Django version
         run: |
@@ -106,7 +106,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --group test --extra djet --extra webauthn
+        run: uv sync --group test --extra webauthn
 
       - name: Install Django version
         run: |
@@ -179,7 +179,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --group test --extra djet --extra webauthn
+        run: uv sync --group test --extra webauthn
 
       - name: Install Django version
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-djet = ["djet>=0.3.0,<0.4.0"]
 webauthn = ["webauthn<1.0"]
 
 # Dev dependencies live in PEP 735 groups so they are not published as

--- a/uv.lock
+++ b/uv.lock
@@ -580,15 +580,6 @@ wheels = [
 ]
 
 [[package]]
-name = "djet"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/d2/7f95f1bc2c4f5007773c986a64adf7f5bf548b2adcec2a5c58b9fb604c38/djet-0.3.0.tar.gz", hash = "sha256:44e59b880fccd36a34d9eae1ac150129ad3bf339f953e32a47e1cda3dc412819", size = 34390, upload-time = "2021-07-29T21:20:13.806Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/99/45b40707de13e14f3798070912a1b2eb6891e0c9f3b445804adc8f3f25e1/djet-0.3.0-py3-none-any.whl", hash = "sha256:94506c7f62f00d706a1c990acea1c3e35e26e6c0bf3d374675f8fd3d7daeaedf", size = 7879, upload-time = "2021-07-29T21:20:11.769Z" },
-]
-
-[[package]]
 name = "djoser"
 version = "2.3.4"
 source = { editable = "." }
@@ -601,9 +592,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-djet = [
-    { name = "djet" },
-]
 webauthn = [
     { name = "webauthn" },
 ]
@@ -644,11 +632,10 @@ requires-dist = [
     { name = "django", specifier = ">=3.2" },
     { name = "djangorestframework", specifier = ">=3.14" },
     { name = "djangorestframework-simplejwt", specifier = ">=5.0,<6.0" },
-    { name = "djet", marker = "extra == 'djet'", specifier = ">=0.3.0,<0.4.0" },
     { name = "social-auth-app-django", specifier = ">=5.0.0,<6.0.0" },
     { name = "webauthn", marker = "extra == 'webauthn'", specifier = "<1.0" },
 ]
-provides-extras = ["djet", "webauthn"]
+provides-extras = ["webauthn"]
 
 [package.metadata.requires-dev]
 code-quality = [


### PR DESCRIPTION
Removes `djet` from djoser entirely. The test suite relies on pytest alone.

## Why

The pytest migration (#893) removed the last `from djet import assertions`. Since then djet has survived only as:

- an optional extra in published metadata (`djoser[djet]`)
- an `--extra djet` install on all 28 CI matrix jobs

Two facts from full-history searches:

- **`djoser/` has never imported djet** — `git log --all -S'djet' -- djoser/` returns nothing
- **it was never documented** — `git log --all -S'djet' -- docs/ README.rst` returns nothing

So `pip install djoser[djet]` only ever installed a test helper that djoser does not call — a development dependency leaking into published metadata.

## Compatibility

Requesting an extra that no longer exists is a **warning, not an error**. Verified against the released 2.3.4:

```
$ uv pip install --dry-run --no-deps 'djoser[nonexistent-extra]==2.3.4'
Resolved 1 package in 255ms
 + djoser==2.3.4
```

So existing `djoser[djet]` pins keep installing; they just stop pulling in djet.

## Changes

- drop `djet` from `[project.optional-dependencies]`
- drop `--extra djet` from the three test-suite jobs
- `uv lock` — 101 → 100 packages, `provides-extras = ["webauthn"]`

## Verified

- **synced the exact CI environment (`uv sync --group test --extra webauthn`), confirmed djet is absent from it, and ran the suite there: 206 passed** — the strongest evidence it is unused
- `make run-hooks` — all hooks pass
- `make build` — wheel METADATA now advertises only `Provides-Extra: webauthn`; the four runtime dependencies are unchanged
- `uv lock --check` — clean
- `make docs` — 6 warnings, the pre-existing baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUccbzSjBjZYvJtzbLjLo7