### PR TITLE
test: pin the 2.x me-403 contract; fix settings-override pollution

### DIFF
--- a/djoser/conf.py
+++ b/djoser/conf.py
@@ -140,7 +140,7 @@ class Settings:
         for setting_name, setting_value in overriden_settings.items():
             value = setting_value
             if isinstance(setting_value, dict):
-                value = getattr(self, setting_name, {})
+                value = ObjDict(getattr(self, setting_name, {}))
                 value.update(ObjDict(setting_value))
             setattr(self, setting_name, value)
 

--- a/testproject/testapp/tests/test_urls/test_method_parity.py
+++ b/testproject/testapp/tests/test_urls/test_method_parity.py
@@ -8,6 +8,7 @@ never the other way around.
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from rest_framework.test import APIClient
 
 User = get_user_model()
@@ -68,17 +69,22 @@ def test_unmapped_method_gets_401_for_anonymous_clients(db):
 
 
 @pytest.mark.django_db
-def test_me_returns_200_for_authenticated_user(parity_user):
+def test_me_delete_returns_403_not_404_when_permission_denied(parity_user):
     """
-    The 2.x `me` action allows any authenticated user to fetch their own profile.
-    Unlike user detail/list, it doesn't check DJOSER permission overrides;
-    authentication alone is sufficient.
+    HIDE_USERS (default True) converts 403->404 for user list/detail, but the
+    2.x `me` action was deliberately excluded — a denied /users/me/ request
+    answers a plain 403. DELETE is used because its permission (user_delete)
+    is resolved at request time, so the override below actually applies.
     """
     client = APIClient()
     client.force_authenticate(user=parity_user)
-    response = client.get("/auth/users/me/")
-    assert response.status_code == 200
-    assert response.data["username"] == "parity"
+    with override_settings(
+        DJOSER={
+            "PERMISSIONS": {"user_delete": ["rest_framework.permissions.IsAdminUser"]}
+        }
+    ):
+        response = client.delete("/auth/users/me/")
+    assert response.status_code == 403
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
PR #920 was merged into master before its fix commit was pushed to the branch, so master carried a weak `test_me_returns_200_for_authenticated_user` test instead of the required 403-contract test. This PR carries that fix commit forward:

1. Replaces the weak test with `test_me_delete_returns_403_not_404_when_permission_denied`, which pins that a denied `/users/me/` request answers 403 (not 404) in 2.x. It uses DELETE instead of GET because DELETE's permission (`user_delete`) is resolved at request time via `get_permissions()`, so `override_settings` actually takes effect.
2. Fixes a one-line bug in `djoser/conf.py`'s `Settings._override_settings`: dict-valued DJOSER overrides were merged into the *shared default* `ObjDict` object in place, so an override made in one test leaked into every later settings reload in the process. The new test's `override_settings(DJOSER={"PERMISSIONS": ...})` call would otherwise pollute later tests (`test_user_delete.py` / `test_user_me.py` DELETE tests fail when the override test runs first, without this fix). The fix copies the existing dict before merging in the override.

## Test plan
- [x] `uv run py.test testproject/testapp/tests/test_urls/test_method_parity.py::test_me_delete_returns_403_not_404_when_permission_denied testproject/testapp/tests/test_user_delete.py testproject/testapp/tests/test_user_me.py -q` — 17 passed
- [x] `uv run py.test testproject -q` — 221 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uYLkj9YnPJ1sNE2Juek2m